### PR TITLE
WOMBATlite-sinking: Spatially variable sinking rates within the generic tracers version of WOMBAT-lite

### DIFF
--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2302,6 +2302,8 @@ module generic_WOMBATlite
         positive=.true.) ! [mol/kg]
     call g_tracer_get_values(tracer_list, 'dicr', 'field', wombat%f_dicr, isd, jsd, ntau=tau, &
         positive=.true.) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'dicp', 'field', wombat%f_dicp, isd, jsd, ntau=tau, &
+        positive=.true.) ! [mol/kg]
     call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau, &
         positive=.true.) ! [mol/kg]
  
@@ -3092,6 +3094,7 @@ module generic_WOMBATlite
                                     - wombat%f_dic(i,j,k) ) * grid_tmask(i,j,k)
         wombat%f_alk(i,j,k) = wombat%f_alk(i,j,k) + wombat%alk_correct(i,j,k)
         wombat%f_dic(i,j,k) = wombat%f_dic(i,j,k) + wombat%dic_correct(i,j,k)
+        wombat%f_dicp(i,j,k) = max(wombat%dic_min * mmol_m3_to_mol_kg, wombat%f_dic(i,j,k))
     enddo; enddo; enddo
 
     ! Set tracers values

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2012,7 +2012,6 @@ module generic_WOMBATlite
     real, dimension(:,ilb:,jlb:), intent(in)   :: sw_pen_band
     real, dimension(:,ilb:,jlb:,:), intent(in) :: opacity_band
 
-    character(len=fm_string_len), parameter :: sub_name = 'generic_WOMBATlite_update_from_source'
     integer                                 :: isc, iec, jsc, jec, isd, ied, jsd, jed, nk, ntau, tn
     integer                                 :: i, j, k, n, nz
     real, dimension(:,:,:), pointer         :: grid_tmask
@@ -2051,6 +2050,11 @@ module generic_WOMBATlite
     real                                    :: avedetbury, avecaco3bury
     real, dimension(:,:,:,:), allocatable   :: n_pools, c_pools
     logical                                 :: used
+
+    character(len=fm_string_len), parameter :: sub_name = 'generic_WOMBATlite_update_from_source'
+    character(len=256), parameter           :: error_header = &
+        '==>Error from ' // trim(mod_name) // '(' // trim(sub_name) // '): '
+    character(len=2048) :: mesg
 
     call g_tracer_get_common(isc, iec, jsc, jec, isd, ied, jsd, jed, nk, ntau, &
         grid_tmask=grid_tmask, grid_kmt=grid_kmt)
@@ -3004,60 +3008,71 @@ module generic_WOMBATlite
 
       if (tn.gt.1) then
         if (abs(n_pools(i,j,k,2) - n_pools(i,j,k,1)).gt.1e-16) then
-          print*, "Error: Ecosystem model is not conserving nitrogen"
-          print*, "       Longitude index = ", i
-          print*, "       Latitude index = ", j
-          print*, "       Depth index and value = ", k, wombat%zm(i,j,k)
-          print*, "       Nested timestep number = ", tn
-          print*, " "
-          print*, "       Biological N budget (molN/kg) at two timesteps ", n_pools(i,j,k,:)
-          print*, " "
-          print*, "        NO3 (molNO3/kg) = ", wombat%f_no3(i,j,k)
-          print*, "        PHY (molN/kg) = ", wombat%f_phy(i,j,k) * 16/122.0
-          print*, "        ZOO (molN/kg) = ", wombat%f_zoo(i,j,k) * 16/122.0
-          print*, "        DET (molN/kg) = ", wombat%f_det(i,j,k) * 16/122.0
-          print*, " "
-          print*, "         phygrow (molC/kg/s) = ", wombat%phygrow(i,j,k)
-          print*, "         detremi (molC/kg/s) = ", wombat%detremi(i,j,k)
-          print*, "         zooresp (molC/kg/s) = ", wombat%zooresp(i,j,k)
-          print*, "         zooexcrphy (molC/kg/s) = ", wombat%zooexcrphy(i,j,k)
-          print*, "         zooexcrdet (molC/kg/s) = ", wombat%zooexcrdet(i,j,k)
-          print*, "         phyresp (molC/kg/s) = ", wombat%phyresp(i,j,k)
-          print*, " "
-          stop
+          write (mesg, '( &
+              "Ecosystem model is not conserving nitrogen",/, &
+              "       Longitude index = ",i6,/, &
+              "       Latitude index = ",i6,/, &
+              "       Depth index and value = ",i6,",",ES13.6,/, &
+              "       Nested timestep number = ",i6,/,/, &
+              "       Biological N budget (molN/kg) at two timesteps = ",ES13.6,",",ES13.6,/,/, &
+              "       NO3 (molNO3/kg) = ",ES13.6,/, &
+              "       PHY (molN/kg) = ",ES13.6,/, &
+              "       ZOO (molN/kg) = ",ES13.6,/, &
+              "       DET (molN/kg) = ",ES13.6,/,/, &
+              "       phygrow (molC/kg/s) = ",ES13.6,/, &
+              "       detremi (molC/kg/s) = ",ES13.6,/, &
+              "       zooresp (molC/kg/s) = ",ES13.6,/, &
+              "       zooexcrphy (molC/kg/s) = ",ES13.6,/, &
+              "       zooexcrdet (molC/kg/s) = ",ES13.6,/, &
+              "       phyresp (molC/kg/s) = ",ES13.6,/ &
+              )') &
+              i, j, k, wombat%zm(i,j,k), tn, n_pools(i,j,k,1), n_pools(i,j,k,2), &
+              wombat%f_no3(i,j,k), wombat%f_phy(i,j,k) * 16/122.0, wombat%f_zoo(i,j,k) * 16/122.0, &
+              wombat%f_det(i,j,k) * 16/122.0, wombat%phygrow(i,j,k), wombat%detremi(i,j,k), &
+              wombat%zooresp(i,j,k), wombat%zooexcrphy(i,j,k), wombat%zooexcrdet(i,j,k), &
+              wombat%phyresp(i,j,k)
+          call mpp_error(FATAL, trim(error_header) // mesg)
         endif
         if (abs(c_pools(i,j,k,2) - c_pools(i,j,k,1)).gt.1e-16) then
-          print*, "Error: Ecosystem model is not conserving carbon"
-          print*, "       Longitude index = ", i
-          print*, "       Latitude index = ", j
-          print*, "       Depth index and value = ", k, wombat%zm(i,j,k)
-          print*, "       Nested timestep number = ", tn
-          print*, " "
-          print*, "       Biological C budget (molC/kg) at two timesteps ", c_pools(i,j,k,:)
-          print*, " "
-          print*, "        DIC (molC/kg) = ", wombat%f_dic(i,j,k)
-          print*, "        ALK (molC/kg) = ", wombat%f_alk(i,j,k)
-          print*, "        PHY (molC/kg) = ", wombat%f_phy(i,j,k)
-          print*, "        ZOO (molC/kg) = ", wombat%f_zoo(i,j,k)
-          print*, "        DET (molC/kg) = ", wombat%f_det(i,j,k)
-          print*, "        CaCO3 (molC/kg) = ", wombat%f_caco3(i,j,k)
-          print*, "        Temp = ", Temp(i,j,k)
-          print*, "        Salt = ", Salt(i,j,k)
-          print*, "        surface pCO2 = ", wombat%pco2_csurf(i,j)
-          print*, "        htotal = ", wombat%htotal(i,j,k)
-          print*, " "
-          print*, "         phygrow (molC/kg/s) = ", wombat%phygrow(i,j,k)
-          print*, "         detremi (molC/kg/s) = ", wombat%detremi(i,j,k)
-          print*, "         zooresp (molC/kg/s) = ", wombat%zooresp(i,j,k)
-          print*, "         zooexcrphy (molC/kg/s) = ", wombat%zooexcrphy(i,j,k)
-          print*, "         zooexcrdet (molC/kg/s) = ", wombat%zooexcrdet(i,j,k)
-          print*, "         phyresp (molC/kg/s) = ", wombat%phyresp(i,j,k)
-          print*, "         zooslopphy * pic2poc(i,j,k) (molC/kg/s) = ", wombat%zooslopphy(i,j,k)*wombat%pic2poc(i,j,k)
-          print*, "         phymort * pic2poc(i,j,k) (molC/kg/s) = ", wombat%phymort(i,j,k)*wombat%pic2poc(i,j,k)
-          print*, "         zoomort * pic2poc(i,j,k) (molC/kg/s) = ", wombat%zoomort(i,j,k)*wombat%pic2poc(i,j,k)
-          print*, "         caldiss (molC/kg/s) = ", wombat%caldiss(i,j,k)
-          print*, " "
-          stop
+          write (mesg, '( &
+              "Ecosystem model is not conserving carbon",/, &
+              "       Longitude index = ",i6,/, &
+              "       Latitude index = ",i6,/, &
+              "       Depth index and value = ",i6,",",ES13.6,/, &
+              "       Nested timestep number = ",i6,/,/, &
+              "       Biological C budget (molC/kg) at two timesteps = ",ES13.6,",",ES13.6,/,/, &
+              "       DIC (molC/kg) = ",ES13.6,/, &
+              "       ALK (molC/kg) = ",ES13.6,/, &
+              "       PHY (molC/kg) = ",ES13.6,/, &
+              "       ZOO (molN/kg) = ",ES13.6,/, &
+              "       DET (molN/kg) = ",ES13.6,/, &
+              "       CaCO3 (molC/kg) = ",ES13.6,/, &
+              "       Temp = ",ES13.6,/, &
+              "       Salt = ",ES13.6,/, &
+              "       surface pCO2 = ",ES13.6,/, &
+              "       htotal = ",ES13.6,/,/, &
+              "       phygrow (molC/kg/s) = ",ES13.6,/, &
+              "       detremi (molC/kg/s) = ",ES13.6,/, &
+              "       zooresp (molC/kg/s) = ",ES13.6,/, &
+              "       zooexcrphy (molC/kg/s) = ",ES13.6,/, &
+              "       zooexcrdet (molC/kg/s) = ",ES13.6,/, &
+              "       phyresp (molC/kg/s) = ",ES13.6,/, &
+              "       zooslopphy * pic2poc(i,j,k) (molC/kg/s) = ",ES13.6,/, &
+              "       phymort * pic2poc(i,j,k) (molC/kg/s) = ",ES13.6,/, &
+              "       zoomort * pic2poc(i,j,k) (molC/kg/s) = ",ES13.6,/, &
+              "       caldiss (molC/kg/s) = ",ES13.6,/ &
+              )') &
+              i, j, k, wombat%zm(i,j,k), tn, c_pools(i,j,k,1), c_pools(i,j,k,2), &
+              wombat%f_dic(i,j,k), wombat%f_alk(i,j,k), wombat%f_phy(i,j,k), wombat%f_zoo(i,j,k), &
+              wombat%f_det(i,j,k), wombat%f_caco3(i,j,k), Temp(i,j,k), Salt(i,j,k), &
+              wombat%pco2_csurf(i,j), wombat%htotal(i,j,k), wombat%phygrow(i,j,k), &
+              wombat%detremi(i,j,k), wombat%zooresp(i,j,k), wombat%zooexcrphy(i,j,k), &
+              wombat%zooexcrdet(i,j,k), wombat%phyresp(i,j,k), &
+              wombat%zooslopphy(i,j,k) * wombat%pic2poc(i,j,k), &
+              wombat%phymort(i,j,k) * wombat%pic2poc(i,j,k), &
+              wombat%zoomort(i,j,k) * wombat%pic2poc(i,j,k), &
+              wombat%caldiss(i,j,k)
+          call mpp_error(FATAL, trim(error_header) // mesg)
         endif
       endif
 

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -108,7 +108,7 @@ module generic_WOMBATlite
   !=======================================================================
   ! Namelist Options
   !=======================================================================
-  character(len=10) :: co2_calc = 'ocmip2' ! other option is 'mocsy'
+  character(len=10) :: co2_calc = 'mocsy' ! other option is 'ocmip2'
 
   namelist /generic_wombatlite_nml/ co2_calc
 

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -3266,10 +3266,12 @@ module generic_WOMBATlite
       call g_tracer_get_pointer(tracer_list, 'no3', 'stf', wombat%p_no3_stf)
       call g_tracer_get_pointer(tracer_list, 'alk', 'stf', wombat%p_alk_stf)
       ! Spread the addition around to all grid cells
-      avedetbury = sum(wombat%p_detbury(:,:,1) * grid_dat(:,:)) / sum(grid_dat(:,:) * grid_tmask(:,:,1))  ! [mol/m2/s]
-      avecaco3bury = sum(wombat%p_caco3bury(:,:,1) * grid_dat(:,:)) / sum(grid_dat(:,:) * grid_tmask(:,:,1))  ! [mol/m2/s]
-      wombat%p_no3_stf(:,:) = wombat%p_no3_stf(:,:) + avedetbury*16.0/122.0   ! [mol/m2/s]
-      wombat%p_alk_stf(:,:) = wombat%p_alk_stf(:,:) - avedetbury*16.0/122.0 + avecaco3bury*2.0  ! [mol/m2/s]
+      if (sum(grid_tmask(:,:,1)).gt.0.0) then
+        avedetbury = sum(wombat%p_detbury(:,:,1) * grid_dat(:,:)) / sum(grid_dat(:,:) * grid_tmask(:,:,1))  ! [mol/m2/s]
+        avecaco3bury = sum(wombat%p_caco3bury(:,:,1) * grid_dat(:,:)) / sum(grid_dat(:,:) * grid_tmask(:,:,1))  ! [mol/m2/s]
+        wombat%p_no3_stf(:,:) = wombat%p_no3_stf(:,:) + avedetbury*16.0/122.0   ! [mol/m2/s]
+        wombat%p_alk_stf(:,:) = wombat%p_alk_stf(:,:) - avedetbury*16.0/122.0 + avecaco3bury*2.0  ! [mol/m2/s]
+      endif
     endif
 
     !=======================================================================

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -162,7 +162,6 @@ module generic_WOMBATlite
         dt_npzd, &
         sal_global, &
         dic_global, &
-        adic_global, &
         alk_global, &
         no3_global, &
         sio2_surf, &
@@ -188,15 +187,13 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------
     real, dimension(:,:), allocatable :: &
         htotallo, htotalhi,  &
-        ahtotallo, ahtotalhi,  &
         sio2, &
         co2_csurf, co2_alpha, co2_sc_no, pco2_csurf, &
-        aco2_csurf, aco2_alpha, paco2_csurf, &
         o2_csurf, o2_alpha, o2_sc_no, &
-        no3_vstf, dic_vstf, adic_vstf, alk_vstf
+        no3_vstf, dic_vstf, dicp_vstf, alk_vstf
 
     real, dimension(:,:,:), allocatable :: &
-        htotal, ahtotal, &
+        htotal, &
         omega_ara, omega_cal, &
         co3, co2_star
 
@@ -207,7 +204,7 @@ module generic_WOMBATlite
     ! to a bottom flux and "p_" to a "pointer".
     real, dimension(:,:), allocatable :: &
         b_dic, &
-        b_adic, &
+        b_dicr, &
         b_alk, &
         b_no3, &
         b_o2, &
@@ -228,7 +225,6 @@ module generic_WOMBATlite
         detfe_sed_bury, &
         caco3_sed_bury, &
         dic_intmld, &
-        adic_intmld, &
         o2_intmld, &
         no3_intmld, &
         fe_intmld, &
@@ -238,7 +234,6 @@ module generic_WOMBATlite
         npp_intmld, &
         radbio_intmld, &
         dic_int100, &
-        adic_int100, &
         o2_int100, &
         no3_int100, &
         fe_int100, &
@@ -251,7 +246,8 @@ module generic_WOMBATlite
       
     real, dimension(:,:,:), allocatable :: &
         f_dic, &
-        f_adic, &
+        f_dicr, &
+        f_dicp, &
         f_alk, &
         f_no3, &
         f_phy, &
@@ -311,7 +307,6 @@ module generic_WOMBATlite
         no3_prev, &
         caco3_prev, &
         dic_correct, &
-        adic_correct, &
         alk_correct, &
         zw, &
         zm
@@ -332,7 +327,7 @@ module generic_WOMBATlite
     real, dimension(:,:), pointer :: &
         p_no3_stf, &
         p_dic_stf, &
-        p_adic_stf, &
+        p_dicp_stf, &
         p_alk_stf
 
     !-----------------------------------------------------------------------
@@ -341,19 +336,16 @@ module generic_WOMBATlite
     ! See register_diagnostics for descriptions of each diagnostic
     integer :: &
         id_pco2 = -1, &
-        id_paco2 = -1, &
         id_htotal = -1, &
-        id_ahtotal = -1, &
         id_omega_ara = -1, &
         id_omega_cal = -1, &
         id_co3 = -1, &
         id_co2_star = -1, &
         id_no3_vstf = -1, &
         id_dic_vstf = -1, &
-        id_adic_vstf = -1, &
+        id_dicp_vstf = -1, &
         id_alk_vstf = -1, &
         id_dic_correct = -1, &
-        id_adic_correct = -1, &
         id_alk_correct = -1, &
         id_light_limit = -1, &
         id_radbio = -1, &
@@ -408,7 +400,6 @@ module generic_WOMBATlite
         id_npp1 = -1, &
         id_zprod_gross = -1, &
         id_dic_intmld = -1, &
-        id_adic_intmld = -1, &
         id_o2_intmld = -1, &
         id_no3_intmld = -1, &
         id_fe_intmld = -1, &
@@ -418,7 +409,6 @@ module generic_WOMBATlite
         id_npp_intmld = -1, &
         id_radbio_intmld = -1, &
         id_dic_int100 = -1, &
-        id_adic_int100 = -1, &
         id_o2_int100 = -1, &
         id_no3_int100 = -1, &
         id_fe_int100 = -1, &
@@ -634,19 +624,8 @@ module generic_WOMBATlite
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
   
     vardesc_temp = vardesc( &
-        'paco2', 'Surface aqueous partial pressure of CO2 inc. anthropogenic', &
-        'h', '1', 's', 'uatm', 'f')
-    wombat%id_paco2 = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
-        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
-
-    vardesc_temp = vardesc( &
         'htotal', 'H+ concentration', 'h', 'L', 's', 'mol/kg', 'f')
     wombat%id_htotal = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
-        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
-
-    vardesc_temp = vardesc( &
-        'ahtotal', 'H+ concentration inc. anthropogenic', 'h', 'L', 's', 'mol/kg', 'f')
-    wombat%id_ahtotal = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
@@ -676,15 +655,15 @@ module generic_WOMBATlite
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
-        'dic_vstf', 'Virtual flux of natural dissolved inorganic carbon into ocean due to '// &
+        'dic_vstf', 'Virtual flux of dissolved inorganic carbon into ocean due to '// &
         'salinity restoring/correction', 'h', '1', 's', 'mol/m^2/s', 'f')
     wombat%id_dic_vstf = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
-        'adic_vstf', 'Virtual flux of natural + anthropogenic dissolved inorganic carbon '// &
-        'into ocean due to salinity restoring/correction', 'h', '1', 's', 'mol/m^2/s', 'f')
-    wombat%id_adic_vstf = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+        'dicp_vstf', 'Virtual flux of preformed dissolved inorganic carbon into ocean due to '// &
+        'salinity restoring/correction', 'h', '1', 's', 'mol/m^2/s', 'f')
+    wombat%id_dicp_vstf = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
@@ -699,11 +678,6 @@ module generic_WOMBATlite
     vardesc_temp = vardesc( &
         'dic_correct', 'Correction to DIC tracer (min limit)',  'h', 'L', 's', 'mol/kg', 'f')
     wombat%id_dic_correct = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
-        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
-    
-    vardesc_temp = vardesc( &
-        'adic_correct', 'Correction to aDIC tracer (min limit)',  'h', 'L', 's', 'mol/kg', 'f')
-    wombat%id_adic_correct = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
     
     vardesc_temp = vardesc( &
@@ -1037,15 +1011,9 @@ module generic_WOMBATlite
     ! MLD-integrated diagnostics
     !-----------------------------------------------------------------------
     vardesc_temp = vardesc( &
-        'dic_intmld', 'MLD-integrated natural dissolved inorganic carbon', &
+        'dic_intmld', 'MLD-integrated dissolved inorganic carbon', &
         'h', '1', 's', 'mol/m^2', 'f')
     wombat%id_dic_intmld = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
-        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
-    
-    vardesc_temp = vardesc( &
-        'adic_intmld', 'MLD-integrated natural + anthropogenic dissolved inorganic carbon', &
-        'h', '1', 's', 'mol/m^2', 'f')
-    wombat%id_adic_intmld = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
     
     vardesc_temp = vardesc( &
@@ -1093,15 +1061,9 @@ module generic_WOMBATlite
     ! 100m-integrated diagnostics
     !-----------------------------------------------------------------------
     vardesc_temp = vardesc( &
-        'dic_int100', '100m-integrated natural dissolved inorganic carbon', &
+        'dic_int100', '100m-integrated dissolved inorganic carbon', &
         'h', '1', 's', 'mol/m^2', 'f')
     wombat%id_dic_int100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
-        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
-    
-    vardesc_temp = vardesc( &
-        'adic_int100', '100m-integrated natural + anthropogenic dissolved inorganic carbon', &
-        'h', '1', 's', 'mol/m^2', 'f')
-    wombat%id_adic_int100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
     
     vardesc_temp = vardesc( &
@@ -1423,10 +1385,6 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------
     call g_tracer_add_param('dic_global', wombat%dic_global, 1.90e-3)
 
-    ! Global average surface adic used for virtual flux correction [mol/kg]
-    !-----------------------------------------------------------------------
-    call g_tracer_add_param('adic_global', wombat%adic_global, 1.90e-3)
-
     ! Global average surface alk used for virtual flux correction [mol/kg]
     !-----------------------------------------------------------------------
     call g_tracer_add_param('alk_global', wombat%alk_global, 2.225e-3)
@@ -1600,11 +1558,11 @@ module generic_WOMBATlite
         flux_bottom = .false., &
         btm_reservoir = .true.)
 
-    ! ADIC (Natural + anthropogenic dissolved inorganic carbon)
+    ! DIC (Dissolved inorganic carbon)
     !-----------------------------------------------------------------------
     call g_tracer_add(tracer_list, package_name, &
-        name = 'adic', &
-        longname = 'Natural + anthropogenic Dissolved Inorganic Carbon', &
+        name = 'dic', &
+        longname = 'Dissolved Inorganic Carbon', &
         units = 'mol/kg', &
         prog = .true., &
         flux_gas = .true., &
@@ -1615,21 +1573,31 @@ module generic_WOMBATlite
         flux_gas_param = (/ as_coeff_wombatlite, 9.7561e-06 /), & ! dts: param(2) converts Pa -> atm
         flux_gas_restart_file = 'ocean_wombatlite_airsea_flux.res.nc', &
         flux_virtual = .true.)
-      
-    ! DIC (Natural dissolved inorganic carbon)
+
+    ! DICp (preformed Dissolved inorganic carbon)
     !-----------------------------------------------------------------------
     call g_tracer_add(tracer_list, package_name, &
-        name = 'dic', &
-        longname = 'Natural Dissolved Inorganic Carbon', &
+        name = 'dicp', &
+        longname = 'preformed Dissolved Inorganic Carbon', &
         units = 'mol/kg', &
         prog = .true., &
         flux_gas = .true., &
-        flux_bottom = .true., &
-        flux_gas_name = 'co2_nat_flux', &
+        flux_bottom = .false., &
+        flux_gas_name = 'co2_pre_flux', &
         flux_gas_type = 'air_sea_gas_flux_generic', &
         flux_gas_molwt = WTMCO2, &
         flux_gas_param = (/ as_coeff_wombatlite, 9.7561e-06 /), & ! dts: param(2) converts Pa -> atm
         flux_gas_restart_file = 'ocean_wombatlite_airsea_flux.res.nc', &
+        flux_virtual = .true.)
+
+    ! DICr (remineralised dissolved inorganic carbon)
+    !-----------------------------------------------------------------------
+    call g_tracer_add(tracer_list, package_name, &
+        name = 'dicr', &
+        longname = 'remineralised Dissolved Inorganic Carbon', &
+        units = 'mol/kg', &
+        prog = .true., &
+        flux_bottom = .true., &
         flux_virtual = .true.)
 
     ! Alk (Total carbonate alkalinity)
@@ -1732,9 +1700,9 @@ module generic_WOMBATlite
     wombat%dic_vstf(:,:) = (wombat%dic_global / wombat%sal_global) * salt_flux_added(:,:) ! [mol/m2/s]
     wombat%p_dic_stf(:,:) = wombat%p_dic_stf(:,:) + wombat%dic_vstf(:,:) ! [mol/m2/s]
 
-    call g_tracer_get_pointer(tracer_list, 'adic', 'stf', wombat%p_adic_stf)
-    wombat%adic_vstf(:,:) = (wombat%adic_global / wombat%sal_global) * salt_flux_added(:,:) ! [mol/m2/s]
-    wombat%p_adic_stf(:,:) = wombat%p_adic_stf(:,:) + wombat%adic_vstf(:,:) ! [mol/m2/s]
+    call g_tracer_get_pointer(tracer_list, 'dicp', 'stf', wombat%p_dicp_stf)
+    wombat%dicp_vstf(:,:) = (wombat%dic_global / wombat%sal_global) * salt_flux_added(:,:) ! [mol/m2/s]
+    wombat%p_dicp_stf(:,:) = wombat%p_dicp_stf(:,:) + wombat%dicp_vstf(:,:) ! [mol/m2/s]
 
     call g_tracer_get_pointer(tracer_list, 'alk', 'stf', wombat%p_alk_stf)
     wombat%alk_vstf(:,:) = (wombat%alk_global / wombat%sal_global) * salt_flux_added(:,:) ! [mol/m2/s]
@@ -2068,8 +2036,6 @@ module generic_WOMBATlite
     
     call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau, &
         positive=.true.)
-    call g_tracer_get_values(tracer_list, 'adic', 'field', wombat%f_adic, isd, jsd, ntau=tau, &
-        positive=.true.)
     call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau, &
         positive=.true.)
     call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau, &
@@ -2079,8 +2045,6 @@ module generic_WOMBATlite
      do j = jsc,jec; do i = isc,iec
        wombat%htotallo(i,j) = wombat%htotal_scale_lo * wombat%htotal(i,j,k)
        wombat%htotalhi(i,j) = wombat%htotal_scale_hi * wombat%htotal(i,j,k)
-       wombat%ahtotallo(i,j) = wombat%htotal_scale_lo * wombat%ahtotal(i,j,k)
-       wombat%ahtotalhi(i,j) = wombat%htotal_scale_hi * wombat%ahtotal(i,j,k)
      enddo; enddo 
 
      if (k.eq.1) then !{
@@ -2096,27 +2060,14 @@ module generic_WOMBATlite
            zt=wombat%zw(:,:,k), &
            co2star=wombat%co2_csurf(:,:), alpha=wombat%co2_alpha(:,:), co3_ion=wombat%co3(:,:,k), &
            pCO2surf=wombat%pco2_csurf(:,:), omega_arag=wombat%omega_ara(:,:,k), omega_calc=wombat%omega_cal(:,:,k))
- 
-       call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
-           Temp(:,:,k), Salt(:,:,k), &
-           min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_adic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
-           max(wombat%f_no3(:,:,k) / 16., 1e-9), &
-           wombat%sio2(:,:), &
-           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
-           wombat%ahtotallo(:,:), wombat%ahtotalhi(:,:), &
-           wombat%ahtotal(:,:,k), &
-           co2_calc=trim(co2_calc), &
-           zt=wombat%zw(:,:,k), &
-           co2star=wombat%aco2_csurf(:,:), alpha=wombat%aco2_alpha(:,:), &
-           pCO2surf=wombat%paco2_csurf(:,:))
 
        call g_tracer_set_values(tracer_list, 'dic', 'alpha', wombat%co2_alpha, isd, jsd)
        call g_tracer_set_values(tracer_list, 'dic', 'csurf', wombat%co2_csurf, isd, jsd)
-       call g_tracer_set_values(tracer_list, 'adic', 'alpha', wombat%aco2_alpha, isd, jsd)
-       call g_tracer_set_values(tracer_list, 'adic', 'csurf', wombat%aco2_csurf, isd, jsd)
-
+       call g_tracer_set_values(tracer_list, 'dicp', 'alpha', wombat%co2_alpha, isd, jsd)
+       call g_tracer_set_values(tracer_list, 'dicp', 'csurf', wombat%co2_csurf, isd, jsd)
+ 
        wombat%co2_star(:,:,1) = wombat%co2_csurf(:,:)
-
+    
      else
 
        call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
@@ -2131,17 +2082,6 @@ module generic_WOMBATlite
            co2star=wombat%co2_star(:,:,k), co3_ion=wombat%co3(:,:,k), &
            omega_arag=wombat%omega_ara(:,:,k), omega_calc=wombat%omega_cal(:,:,k))
 
-       call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
-           Temp(:,:,k), Salt(:,:,k), &
-           min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_adic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
-           max(wombat%f_no3(:,:,k) / 16., 1e-9), &
-           wombat%sio2(:,:), &
-           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
-           wombat%ahtotallo(:,:), wombat%ahtotalhi(:,:), &
-           wombat%ahtotal(:,:,k), &
-           co2_calc=trim(co2_calc), &
-           zt=wombat%zw(:,:,k))
-
      endif !} if k.eq.1
    enddo !} do k = 1,nk
 
@@ -2150,7 +2090,6 @@ module generic_WOMBATlite
     !=======================================================================
 
     wombat%dic_correct(:,:,:) = 0.0
-    wombat%adic_correct(:,:,:) = 0.0
     wombat%alk_correct(:,:,:) = 0.0
     wombat%pprod_gross(:,:,:) = 0.0
     wombat%zprod_gross(:,:,:) = 0.0
@@ -2199,7 +2138,6 @@ module generic_WOMBATlite
     wombat%caldiss(:,:,:) = 0.0
     wombat%export_prod(:,:) = 0.0
     wombat%export_inorg(:,:) = 0.0
-    wombat%adic_intmld(:,:) = 0.0
     wombat%dic_intmld(:,:) = 0.0
     wombat%o2_intmld(:,:) = 0.0
     wombat%no3_intmld(:,:) = 0.0
@@ -2209,7 +2147,6 @@ module generic_WOMBATlite
     wombat%pprod_gross_intmld(:,:) = 0.0
     wombat%npp_intmld(:,:) = 0.0
     wombat%radbio_intmld(:,:) = 0.0
-    wombat%adic_int100(:,:) = 0.0
     wombat%dic_int100(:,:) = 0.0
     wombat%o2_int100(:,:) = 0.0
     wombat%no3_int100(:,:) = 0.0
@@ -2273,9 +2210,9 @@ module generic_WOMBATlite
         positive=.true.) ! [mol/kg]
     call g_tracer_get_values(tracer_list, 'fe', 'field', wombat%f_fe, isd, jsd, ntau=tau, &
         positive=.true.) ! [mol/kg]
-   call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau, &
+    call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau, &
         positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'adic', 'field', wombat%f_adic, isd, jsd, ntau=tau, &
+    call g_tracer_get_values(tracer_list, 'dicr', 'field', wombat%f_dicr, isd, jsd, ntau=tau, &
         positive=.true.) ! [mol/kg]
     call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau, &
         positive=.true.) ! [mol/kg]
@@ -2874,9 +2811,9 @@ module generic_WOMBATlite
                               wombat%zoomort(i,j,k) * wombat%pic2poc(i,j,k) + &  
                               wombat%caldiss(i,j,k) )
 
-      ! Equation for aDIC ! [molC/kg]
+      ! Equation for DICr ! [molC/kg]
       !-----------------------------------------------------------------------
-      wombat%f_adic(i,j,k) = wombat%f_adic(i,j,k) + dtsb * ( &
+      wombat%f_dicr(i,j,k) = wombat%f_dicr(i,j,k) + dtsb * ( &
                                wombat%detremi(i,j,k) + &
                                wombat%zooresp(i,j,k) + &
                                wombat%zooexcrphy(i,j,k) + &
@@ -3019,7 +2956,6 @@ module generic_WOMBATlite
       wombat%fesinks(i,j,k) = rdtts * wombat%fesinks(i,j,k) * grid_tmask(i,j,k) ! [mol/kg/s]
 
       if (wombat%zw(i,j,k) .le. hblt_depth(i,j)) then
-        wombat%adic_intmld(i,j) = wombat%adic_intmld(i,j) + wombat%f_adic(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
         wombat%dic_intmld(i,j) = wombat%dic_intmld(i,j) + wombat%f_dic(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
         wombat%o2_intmld(i,j)  = wombat%o2_intmld(i,j)  + wombat%f_o2(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
         wombat%no3_intmld(i,j) = wombat%no3_intmld(i,j) + wombat%f_no3(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
@@ -3033,7 +2969,6 @@ module generic_WOMBATlite
       endif
 
       if (wombat%zw(i,j,k) .le. 100) then
-        wombat%adic_int100(i,j) = wombat%adic_int100(i,j) + wombat%f_adic(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
         wombat%dic_int100(i,j) = wombat%dic_int100(i,j) + wombat%f_dic(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
         wombat%o2_int100(i,j)  = wombat%o2_int100(i,j)  + wombat%f_o2(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
         wombat%no3_int100(i,j) = wombat%no3_int100(i,j) + wombat%f_no3(i,j,k) * rho_dzt(i,j,k) ! [mol/m2]
@@ -3067,11 +3002,8 @@ module generic_WOMBATlite
                                     - wombat%f_alk(i,j,k) ) * grid_tmask(i,j,k)
         wombat%dic_correct(i,j,k) = (max(wombat%dic_min * mmol_m3_to_mol_kg, wombat%f_dic(i,j,k) ) &
                                     - wombat%f_dic(i,j,k) ) * grid_tmask(i,j,k)
-        wombat%adic_correct(i,j,k) = (max(wombat%dic_min * mmol_m3_to_mol_kg, wombat%f_adic(i,j,k) ) &
-                                     - wombat%f_adic(i,j,k) ) * grid_tmask(i,j,k)
         wombat%f_alk(i,j,k) = wombat%f_alk(i,j,k) + wombat%alk_correct(i,j,k)
         wombat%f_dic(i,j,k) = wombat%f_dic(i,j,k) + wombat%dic_correct(i,j,k)
-        wombat%f_adic(i,j,k) = wombat%f_adic(i,j,k) + wombat%adic_correct(i,j,k)
     enddo; enddo; enddo
 
     ! Set tracers values
@@ -3087,7 +3019,7 @@ module generic_WOMBATlite
     call g_tracer_set_values(tracer_list, 'caco3', 'field', wombat%f_caco3, isd, jsd, ntau=tau)
     call g_tracer_set_values(tracer_list, 'fe', 'field', wombat%f_fe, isd, jsd, ntau=tau)
     call g_tracer_set_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'adic', 'field', wombat%f_adic, isd, jsd, ntau=tau)
+    call g_tracer_set_values(tracer_list, 'dicr', 'field', wombat%f_dicr, isd, jsd, ntau=tau)
     call g_tracer_set_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau)
 
 
@@ -3138,7 +3070,7 @@ module generic_WOMBATlite
         wombat%b_no3(i,j) = -16./122. * wombat%det_sed_remin(i,j) ! [mol/m2/s]
         wombat%b_o2(i,j) = -172./16. * wombat%b_no3(i,j) ! [mol/m2/s]
         wombat%b_dic(i,j) = 122./16. * wombat%b_no3(i,j) - wombat%caco3_sed_remin(i,j) ! [mol/m2/s]
-        wombat%b_adic(i,j) = wombat%b_dic(i,j) ! [mol/m2/s]
+        wombat%b_dicr(i,j) = wombat%b_dic(i,j) ! [mol/m2/s]
         wombat%b_fe(i,j) = -1.0 * wombat%detfe_sed_remin(i,j) ! [mol/m2/s]
         wombat%b_alk(i,j) = -2.0 * wombat%caco3_sed_remin(i,j) - wombat%b_no3(i,j) ! [mol/m2/s]
 
@@ -3158,7 +3090,7 @@ module generic_WOMBATlite
     call g_tracer_set_values(tracer_list, 'no3', 'btf', wombat%b_no3, isd, jsd)
     call g_tracer_set_values(tracer_list, 'o2', 'btf', wombat%b_o2, isd, jsd)
     call g_tracer_set_values(tracer_list, 'dic', 'btf', wombat%b_dic, isd, jsd)
-    call g_tracer_set_values(tracer_list, 'adic', 'btf', wombat%b_adic, isd, jsd)
+    call g_tracer_set_values(tracer_list, 'dicr', 'btf', wombat%b_dicr, isd, jsd)
     call g_tracer_set_values(tracer_list, 'fe', 'btf', wombat%b_fe, isd, jsd)
     call g_tracer_set_values(tracer_list, 'alk', 'btf', wombat%b_alk, isd, jsd)
 
@@ -3170,16 +3102,8 @@ module generic_WOMBATlite
       used = g_send_data(wombat%id_pco2, wombat%pco2_csurf, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
-    if (wombat%id_paco2 .gt. 0) &
-      used = g_send_data(wombat%id_paco2, wombat%paco2_csurf, model_time, &
-          rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
     if (wombat%id_htotal .gt. 0) &
       used = g_send_data(wombat%id_htotal, wombat%htotal, model_time, &
-          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
-
-    if (wombat%id_ahtotal .gt. 0) &
-      used = g_send_data(wombat%id_ahtotal, wombat%ahtotal, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
     if (wombat%id_omega_ara .gt. 0) &
@@ -3206,8 +3130,8 @@ module generic_WOMBATlite
       used = g_send_data(wombat%id_dic_vstf, wombat%dic_vstf, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
-    if (wombat%id_adic_vstf .gt. 0) &
-      used = g_send_data(wombat%id_adic_vstf, wombat%adic_vstf, model_time, &
+    if (wombat%id_dicp_vstf .gt. 0) &
+      used = g_send_data(wombat%id_dicp_vstf, wombat%dicp_vstf, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
     if (wombat%id_alk_vstf .gt. 0) &
@@ -3216,10 +3140,6 @@ module generic_WOMBATlite
 
     if (wombat%id_dic_correct .gt. 0) &
       used = g_send_data(wombat%id_dic_correct, wombat%dic_correct, model_time, &
-          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
-
-    if (wombat%id_adic_correct .gt. 0) &
-      used = g_send_data(wombat%id_adic_correct, wombat%adic_correct, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
     if (wombat%id_alk_correct .gt. 0) &
@@ -3451,10 +3371,6 @@ module generic_WOMBATlite
       used = g_send_data(wombat%id_zprod_gross, wombat%zprod_gross, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
-    if (wombat%id_adic_intmld .gt. 0) &
-      used = g_send_data(wombat%id_adic_intmld, wombat%adic_intmld, model_time, &
-          rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
     if (wombat%id_dic_intmld .gt. 0) &
       used = g_send_data(wombat%id_dic_intmld, wombat%dic_intmld, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -3489,10 +3405,6 @@ module generic_WOMBATlite
 
     if (wombat%id_radbio_intmld .gt. 0) &
       used = g_send_data(wombat%id_radbio_intmld, wombat%radbio_intmld, model_time, &
-          rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-    if (wombat%id_adic_int100 .gt. 0) &
-      used = g_send_data(wombat%id_adic_int100, wombat%adic_int100, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
     if (wombat%id_dic_int100 .gt. 0) &
@@ -3630,8 +3542,6 @@ module generic_WOMBATlite
       ! Get necessary fields
       call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=1, &
           positive=.true.)
-      call g_tracer_get_values(tracer_list, 'adic', 'field', wombat%f_adic, isd, jsd, ntau=1, &
-          positive=.true.)
       call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=1, &
           positive=.true.)
       call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=1, &
@@ -3640,8 +3550,6 @@ module generic_WOMBATlite
       do j = jsc, jec; do i = isc, iec
           wombat%htotallo(i,j) = wombat%htotal_scale_lo * wombat%htotal(i,j,1)
           wombat%htotalhi(i,j) = wombat%htotal_scale_hi * wombat%htotal(i,j,1)
-          wombat%ahtotallo(i,j) = wombat%htotal_scale_lo * wombat%ahtotal(i,j,1)
-          wombat%ahtotalhi(i,j) = wombat%htotal_scale_hi * wombat%ahtotal(i,j,1)
       enddo; enddo 
 
       if ((trim(co2_calc) == 'mocsy') .and. (.not. present(dzt))) then
@@ -3662,23 +3570,10 @@ module generic_WOMBATlite
           co2star=wombat%co2_csurf(:,:), alpha=wombat%co2_alpha(:,:), co3_ion=wombat%co3(:,:,1), &
           pCO2surf=wombat%pco2_csurf(:,:), omega_arag=wombat%omega_ara(:,:,1), omega_calc=wombat%omega_cal(:,:,1))
 
-      call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,1), &
-          SST(:,:), SSS(:,:), &
-          min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_adic(:,:,1), wombat%dic_min*mmol_m3_to_mol_kg)), &
-          max(wombat%f_no3(:,:,1) / 16., 1e-9), &
-          wombat%sio2(:,:), &
-          min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,1), wombat%alk_min*mmol_m3_to_mol_kg)), &
-          wombat%ahtotallo(:,:), wombat%ahtotalhi(:,:), &
-          wombat%ahtotal(:,:,1), &
-          co2_calc=trim(co2_calc), &
-          zt=dzt(:,:,1), &
-          co2star=wombat%aco2_csurf(:,:), alpha=wombat%aco2_alpha(:,:), &
-          pCO2surf=wombat%paco2_csurf(:,:))
-
       call g_tracer_set_values(tracer_list, 'dic', 'alpha', wombat%co2_alpha, isd, jsd)
       call g_tracer_set_values(tracer_list, 'dic', 'csurf', wombat%co2_csurf, isd, jsd)
-      call g_tracer_set_values(tracer_list, 'adic', 'alpha', wombat%aco2_alpha, isd, jsd)
-      call g_tracer_set_values(tracer_list, 'adic', 'csurf', wombat%aco2_csurf, isd, jsd)
+      call g_tracer_set_values(tracer_list, 'dicp', 'alpha', wombat%co2_alpha, isd, jsd)
+      call g_tracer_set_values(tracer_list, 'dicp', 'csurf', wombat%co2_csurf, isd, jsd)
 
       ! nnz: If source is called uncomment the following
       wombat%init = .false. !nnz: This is necessary since the above calls appear in source subroutine too.
@@ -3686,8 +3581,6 @@ module generic_WOMBATlite
 
     call g_tracer_get_values(tracer_list, 'dic', 'alpha', wombat%co2_alpha ,isd, jsd)
     call g_tracer_get_values(tracer_list, 'dic', 'csurf', wombat%co2_csurf ,isd, jsd)
-    call g_tracer_get_values(tracer_list, 'adic', 'alpha', wombat%aco2_alpha ,isd, jsd)
-    call g_tracer_get_values(tracer_list, 'adic', 'csurf', wombat%aco2_csurf ,isd, jsd)
 
     do j=jsc,jec ; do i=isc,iec
       !-----------------------------------------------------------------------
@@ -3700,8 +3593,6 @@ module generic_WOMBATlite
       
       wombat%co2_alpha(i,j) = wombat%co2_alpha(i,j) * wombat%Rho_0 !nnz: MOM has rho(i,j,1,tau)
       wombat%co2_csurf(i,j) = wombat%co2_csurf(i,j) * wombat%Rho_0 !nnz: MOM has rho(i,j,1,tau)
-      wombat%aco2_alpha(i,j) = wombat%aco2_alpha(i,j) * wombat%Rho_0 !nnz: MOM has rho(i,j,1,tau)
-      wombat%aco2_csurf(i,j) = wombat%aco2_csurf(i,j) * wombat%Rho_0 !nnz: MOM has rho(i,j,1,tau)
     enddo; enddo
 
     ! Set %csurf, %alpha and %sc_no for these tracers. This will mark them
@@ -3709,9 +3600,10 @@ module generic_WOMBATlite
     call g_tracer_set_values(tracer_list, 'dic', 'alpha', wombat%co2_alpha, isd, jsd)
     call g_tracer_set_values(tracer_list, 'dic', 'csurf', wombat%co2_csurf, isd, jsd)
     call g_tracer_set_values(tracer_list, 'dic', 'sc_no', wombat%co2_sc_no, isd, jsd)
-    call g_tracer_set_values(tracer_list, 'adic', 'alpha', wombat%aco2_alpha, isd, jsd)
-    call g_tracer_set_values(tracer_list, 'adic', 'csurf', wombat%aco2_csurf, isd, jsd)
-    call g_tracer_set_values(tracer_list, 'adic', 'sc_no', wombat%co2_sc_no, isd, jsd)
+
+    call g_tracer_set_values(tracer_list, 'dicp', 'alpha', wombat%co2_alpha, isd, jsd)
+    call g_tracer_set_values(tracer_list, 'dicp', 'csurf', wombat%co2_csurf, isd, jsd)
+    call g_tracer_set_values(tracer_list, 'dicp', 'sc_no', wombat%co2_sc_no, isd, jsd)
 
     call g_tracer_get_values(tracer_list, 'o2', 'alpha', wombat%o2_alpha, isd, jsd)
     call g_tracer_get_values(tracer_list, 'o2', 'csurf', wombat%o2_csurf ,isd, jsd)
@@ -3816,9 +3708,6 @@ module generic_WOMBATlite
     allocate(wombat%htotallo(isd:ied, jsd:jed)); wombat%htotallo(:,:)=0.0
     allocate(wombat%htotalhi(isd:ied, jsd:jed)); wombat%htotalhi(:,:)=0.0
     allocate(wombat%htotal(isd:ied, jsd:jed, 1:nk)); wombat%htotal(:,:,:)=wombat%htotal_in
-    allocate(wombat%ahtotallo(isd:ied, jsd:jed)); wombat%ahtotallo(:,:)=0.0
-    allocate(wombat%ahtotalhi(isd:ied, jsd:jed)); wombat%ahtotalhi(:,:)=0.0
-    allocate(wombat%ahtotal(isd:ied, jsd:jed, 1:nk)); wombat%ahtotal(:,:,:)=wombat%htotal_in
     allocate(wombat%omega_ara(isd:ied, jsd:jed, 1:nk)); wombat%omega_ara(:,:,:)=1.0
     allocate(wombat%omega_cal(isd:ied, jsd:jed, 1:nk)); wombat%omega_cal(:,:,:)=1.0
     allocate(wombat%co3(isd:ied, jsd:jed, 1:nk)); wombat%co3(:,:,:)=0.0
@@ -3828,19 +3717,17 @@ module generic_WOMBATlite
     allocate(wombat%co2_alpha(isd:ied, jsd:jed)); wombat%co2_alpha(:,:)=0.0
     allocate(wombat%co2_sc_no(isd:ied, jsd:jed)); wombat%co2_sc_no(:,:)=0.0
     allocate(wombat%pco2_csurf(isd:ied, jsd:jed)); wombat%pco2_csurf(:,:)=0.0
-    allocate(wombat%aco2_csurf(isd:ied, jsd:jed)); wombat%aco2_csurf(:,:)=0.0
-    allocate(wombat%aco2_alpha(isd:ied, jsd:jed)); wombat%aco2_alpha(:,:)=0.0
-    allocate(wombat%paco2_csurf(isd:ied, jsd:jed)); wombat%paco2_csurf(:,:)=0.0
     allocate(wombat%o2_csurf(isd:ied, jsd:jed)); wombat%o2_csurf(:,:)=0.0
     allocate(wombat%o2_alpha(isd:ied, jsd:jed)); wombat%o2_alpha(:,:)=0.0
     allocate(wombat%o2_sc_no(isd:ied, jsd:jed)); wombat%o2_sc_no(:,:)=0.0
     allocate(wombat%no3_vstf(isd:ied, jsd:jed)); wombat%no3_vstf(:,:)=0.0
     allocate(wombat%dic_vstf(isd:ied, jsd:jed)); wombat%dic_vstf(:,:)=0.0
-    allocate(wombat%adic_vstf(isd:ied, jsd:jed)); wombat%adic_vstf(:,:)=0.0
+    allocate(wombat%dicp_vstf(isd:ied, jsd:jed)); wombat%dicp_vstf(:,:)=0.0
     allocate(wombat%alk_vstf(isd:ied, jsd:jed)); wombat%alk_vstf(:,:)=0.0
 
     allocate(wombat%f_dic(isd:ied, jsd:jed, 1:nk)); wombat%f_dic(:,:,:)=0.0
-    allocate(wombat%f_adic(isd:ied, jsd:jed, 1:nk)); wombat%f_adic(:,:,:)=0.0
+    allocate(wombat%f_dicp(isd:ied, jsd:jed, 1:nk)); wombat%f_dicp(:,:,:)=0.0
+    allocate(wombat%f_dicr(isd:ied, jsd:jed, 1:nk)); wombat%f_dicr(:,:,:)=0.0
     allocate(wombat%f_alk(isd:ied, jsd:jed, 1:nk)); wombat%f_alk(:,:,:)=0.0
     allocate(wombat%f_no3(isd:ied, jsd:jed, 1:nk)); wombat%f_no3(:,:,:)=0.0
     allocate(wombat%f_phy(isd:ied, jsd:jed, 1:nk)); wombat%f_phy(:,:,:)=0.0
@@ -3857,12 +3744,11 @@ module generic_WOMBATlite
     allocate(wombat%b_no3(isd:ied, jsd:jed)); wombat%b_no3(:,:)=0.0
     allocate(wombat%b_o2(isd:ied, jsd:jed)); wombat%b_o2(:,:)=0.0
     allocate(wombat%b_dic(isd:ied, jsd:jed)); wombat%b_dic(:,:)=0.0
-    allocate(wombat%b_adic(isd:ied, jsd:jed)); wombat%b_adic(:,:)=0.0
+    allocate(wombat%b_dicr(isd:ied, jsd:jed)); wombat%b_dicr(:,:)=0.0
     allocate(wombat%b_fe(isd:ied, jsd:jed)); wombat%b_fe(:,:)=0.0
     allocate(wombat%b_alk(isd:ied, jsd:jed)); wombat%b_alk(:,:)=0.0
 
     allocate(wombat%dic_correct(isd:ied, jsd:jed, 1:nk)); wombat%dic_correct(:,:,:)=0.0
-    allocate(wombat%adic_correct(isd:ied, jsd:jed, 1:nk)); wombat%adic_correct(:,:,:)=0.0
     allocate(wombat%alk_correct(isd:ied, jsd:jed, 1:nk)); wombat%alk_correct(:,:,:)=0.0
     allocate(wombat%light_limit(isd:ied, jsd:jed)); wombat%light_limit(:,:)=0.0
     allocate(wombat%radbio(isd:ied, jsd:jed, 1:nk)); wombat%radbio(:,:,:)=0.0
@@ -3929,7 +3815,6 @@ module generic_WOMBATlite
     allocate(wombat%zm(isd:ied, jsd:jed, 1:nk)); wombat%zm(:,:,:)=0.0
 
     allocate(wombat%dic_intmld(isd:ied, jsd:jed)); wombat%dic_intmld(:,:)=0.0
-    allocate(wombat%adic_intmld(isd:ied, jsd:jed)); wombat%adic_intmld(:,:)=0.0
     allocate(wombat%o2_intmld(isd:ied, jsd:jed)); wombat%o2_intmld(:,:)=0.0
     allocate(wombat%no3_intmld(isd:ied, jsd:jed)); wombat%no3_intmld(:,:)=0.0
     allocate(wombat%fe_intmld(isd:ied, jsd:jed)); wombat%fe_intmld(:,:)=0.0
@@ -3940,7 +3825,6 @@ module generic_WOMBATlite
     allocate(wombat%radbio_intmld(isd:ied, jsd:jed)); wombat%radbio_intmld(:,:)=0.0
 
     allocate(wombat%dic_int100(isd:ied, jsd:jed)); wombat%dic_int100(:,:)=0.0
-    allocate(wombat%adic_int100(isd:ied, jsd:jed)); wombat%adic_int100(:,:)=0.0
     allocate(wombat%o2_int100(isd:ied, jsd:jed)); wombat%o2_int100(:,:)=0.0
     allocate(wombat%no3_int100(isd:ied, jsd:jed)); wombat%no3_int100(:,:)=0.0
     allocate(wombat%fe_int100(isd:ied, jsd:jed)); wombat%fe_int100(:,:)=0.0
@@ -3964,9 +3848,6 @@ module generic_WOMBATlite
         wombat%htotallo, &
         wombat%htotalhi, &
         wombat%htotal, &
-        wombat%ahtotallo, &
-        wombat%ahtotalhi, &
-        wombat%ahtotal, &
         wombat%omega_ara, &
         wombat%omega_cal, &
         wombat%co3, &
@@ -3975,20 +3856,18 @@ module generic_WOMBATlite
         wombat%co2_alpha, &
         wombat%co2_sc_no, &
         wombat%pco2_csurf, &
-        wombat%aco2_csurf, &
-        wombat%aco2_alpha, &
-        wombat%paco2_csurf, &
         wombat%o2_csurf, &
         wombat%o2_alpha, &
         wombat%o2_sc_no, &
         wombat%no3_vstf, &
         wombat%dic_vstf, &
-        wombat%adic_vstf, &
+        wombat%dicp_vstf, &
         wombat%alk_vstf)
 
     deallocate( &
         wombat%f_dic, &
-        wombat%f_adic, &
+        wombat%f_dicp, &
+        wombat%f_dicr, &
         wombat%f_alk, &
         wombat%f_no3, &
         wombat%f_phy, &
@@ -4006,7 +3885,7 @@ module generic_WOMBATlite
         wombat%b_no3, &
         wombat%b_o2, &
         wombat%b_dic, &
-        wombat%b_adic, &
+        wombat%b_dicr, &
         wombat%b_fe, &
         wombat%b_alk)
 
@@ -4076,7 +3955,6 @@ module generic_WOMBATlite
 
     deallocate( &
         wombat%dic_intmld, &
-        wombat%adic_intmld, &
         wombat%o2_intmld, &
         wombat%no3_intmld, &
         wombat%fe_intmld, &
@@ -4086,7 +3964,6 @@ module generic_WOMBATlite
         wombat%npp_intmld, &
         wombat%radbio_intmld, &
         wombat%dic_int100, &
-        wombat%adic_int100, &
         wombat%o2_int100, &
         wombat%no3_int100, &
         wombat%fe_int100, &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2034,6 +2034,7 @@ module generic_WOMBATlite
     real                                    :: phy_minqfe, phy_maxqfe
     real                                    :: zoo_slmor, epsmin
     real                                    :: hco3, diss_cal, diss_ara, diss_det
+    real                                    :: avedetbury, avecaco3bury
     real, dimension(:,:,:,:), allocatable   :: n_pools, c_pools
     logical                                 :: used
 
@@ -3264,9 +3265,11 @@ module generic_WOMBATlite
       call g_tracer_get_pointer(tracer_list, 'caco3bury', 'field', wombat%p_caco3bury) ! [mol/m2/s]
       call g_tracer_get_pointer(tracer_list, 'no3', 'stf', wombat%p_no3_stf)
       call g_tracer_get_pointer(tracer_list, 'alk', 'stf', wombat%p_alk_stf)
-      wombat%p_no3_stf(:,:) = wombat%p_no3_stf(:,:) + wombat%p_detbury(:,:,1)*16.0/122.0   ! [mol/m2/s]
-      wombat%p_alk_stf(:,:) = wombat%p_alk_stf(:,:) - wombat%p_detbury(:,:,1)*16.0/122.0 &
-                                                    + wombat%p_caco3bury(:,:,1) * 2.0      ! [mol/m2/s]
+      ! Spread the addition around to all grid cells
+      avedetbury = sum(wombat%p_detbury(:,:,1) * grid_dat(:,:)) / sum(grid_dat(:,:) * grid_tmask(:,:,1))  ! [mol/m2/s]
+      avecaco3bury = sum(wombat%p_caco3bury(:,:,1) * grid_dat(:,:)) / sum(grid_dat(:,:) * grid_tmask(:,:,1))  ! [mol/m2/s]
+      wombat%p_no3_stf(:,:) = wombat%p_no3_stf(:,:) + avedetbury*16.0/122.0   ! [mol/m2/s]
+      wombat%p_alk_stf(:,:) = wombat%p_alk_stf(:,:) - avedetbury*16.0/122.0 + avecaco3bury*2.0  ! [mol/m2/s]
     endif
 
     !=======================================================================

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -146,6 +146,7 @@ module generic_WOMBATlite
         detlrem, &
         detlrem_sed, &
         wdetbio, &
+        phybiot, &
         caco3lrem, &
         caco3lrem_sed, &
         wcaco3, &
@@ -260,6 +261,8 @@ module generic_WOMBATlite
         phy_mumax, &
         phy_mu, &
         pchl_mu, &
+        phy_kni, &
+        phy_kfe, &
         phy_lpar, &
         phy_lnit, &
         phy_lfer, &
@@ -273,6 +276,8 @@ module generic_WOMBATlite
         fecoag2det, &
         fesources, &
         fesinks, &
+        phy_feupreg, &
+        phy_fedoreg, &
         phygrow, &
         phyresp, &
         phymort, &
@@ -281,6 +286,7 @@ module generic_WOMBATlite
         zoomort, &
         zooexcr, &
         zooslop, &
+        reminr, &
         detremi, &
         caldiss, &
         no3_prev, &
@@ -323,6 +329,8 @@ module generic_WOMBATlite
         id_radmid3d = -1, &
         id_radbio1 = -1, &
         id_pprod_gross = -1, &
+        id_phy_kni = -1, &
+        id_phy_kfe = -1, &
         id_phy_lpar = -1, &
         id_phy_lnit = -1, &
         id_phy_lfer = -1, &
@@ -336,6 +344,8 @@ module generic_WOMBATlite
         id_fecoag2det = -1, &
         id_fesources = -1, &
         id_fesinks = -1, &
+        id_phy_feupreg = -1, &
+        id_phy_fedoreg = -1, &
         id_phygrow = -1, &
         id_phyresp = -1, &
         id_phymort = -1, &
@@ -344,6 +354,7 @@ module generic_WOMBATlite
         id_zoomort = -1, &
         id_zooexcr = -1, &
         id_zooslop = -1, &
+        id_reminr = -1, &
         id_detremi = -1, &
         id_caldiss = -1, &
         id_phy_mumax = -1, &
@@ -743,6 +754,16 @@ module generic_WOMBATlite
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
+        'phy_kni', 'Half-saturation coefficient of nitrogen uptake by phytoplankton', 'h', 'L', 's', 'mmol/m3', 'f')
+    wombat%id_phy_kni = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'phy_kfe', 'Half-saturation coefficient of iron uptake by phytoplankton', 'h', 'L', 's', 'umol/m3', 'f')
+    wombat%id_phy_kfe = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
         'phy_lnit', 'Limitation of phytoplankton by nitrogen', 'h', 'L', 's', '[0-1]', 'f')
     wombat%id_phy_lnit = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
@@ -803,6 +824,16 @@ module generic_WOMBATlite
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
+        'phy_feupreg', 'Factor up regulation of dFe uptake by phytoplankton', 'h', 'L', 's', ' ', 'f')
+    wombat%id_phy_feupreg = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+      'phy_fedoreg', 'Factor down regulation of dFe uptake by phytoplankton', 'h', 'L', 's', ' ', 'f')
+    wombat%id_phy_fedoreg = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
         'phygrow', 'Growth of phytoplankton', 'h', 'L', 's', 'molC/kg/s', 'f')
     wombat%id_phygrow = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
@@ -840,6 +871,11 @@ module generic_WOMBATlite
     vardesc_temp = vardesc( &
         'zooslop', 'Sloppy feeding of zootoplankton', 'h', 'L', 's', 'molC/kg/s', 'f')
     wombat%id_zooslop = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'reminr', 'rate of remineralisation', 'h', 'L', 's', '/s', 'f')
+    wombat%id_reminr = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
@@ -1129,11 +1165,11 @@ module generic_WOMBATlite
 
     ! Phytoplankton linear mortality rate constant [1/s]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('phylmor', wombat%phylmor, 0.005/86400.0)
+    call g_tracer_add_param('phylmor', wombat%phylmor, 0.01/86400.0)
 
     ! Phytoplankton quadratic mortality rate constant [m3/mmolN/s]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('phyqmor', wombat%phyqmor, 0.025/86400.0)
+    call g_tracer_add_param('phyqmor', wombat%phyqmor, 0.05/86400.0)
 
     ! Zooplankton assimilation efficiency [1]
     !-----------------------------------------------------------------------
@@ -1149,7 +1185,7 @@ module generic_WOMBATlite
 
     ! Zooplankton prey capture rate constant [m6/mmol2/s]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('zooepsi', wombat%zooepsi, 0.05/86400.0)
+    call g_tracer_add_param('zooepsi', wombat%zooepsi, 0.25/86400.0)
 
     ! Zooplankton respiration rate constant [1/s]
     !-----------------------------------------------------------------------
@@ -1171,6 +1207,10 @@ module generic_WOMBATlite
     ! consistent with what is in ACCESS-ESM1.5 (undocumented in Ziehn et al
     ! 2020)
     call g_tracer_add_param('detlrem_sed', wombat%detlrem_sed, 0.02/86400.0)
+    
+    ! Phytoplankton biomass threshold to scale recycling [mmolC/m3]
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('phybiot', wombat%phybiot, 0.5)
 
     ! CaCO3 remineralisation rate constant [1/s]
     !-----------------------------------------------------------------------
@@ -1200,7 +1240,7 @@ module generic_WOMBATlite
 
     ! Scavenging of Fe` onto biogenic particles [(mmolC/m3)-1 d-1]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('kscav_dfe', wombat%kscav_dfe, 0.005)
+    call g_tracer_add_param('kscav_dfe', wombat%kscav_dfe, 5e-6)
 
     ! Iron background concentration [umol Fe m^-3]
     !-----------------------------------------------------------------------
@@ -1711,7 +1751,7 @@ module generic_WOMBATlite
     real                                    :: swpar
     real                                    :: u_npz, g_npz
     real                                    :: biophy, biozoo, biodet, biono3, biofer, biocaco3
-    real                                    :: biophyfe 
+    real                                    :: biophyfe, biophy1 
     real                                    :: fbc
     real                                    :: no3_bgc_change, caco3_bgc_change
     real                                    :: epsi = 1.0e-30
@@ -1719,7 +1759,6 @@ module generic_WOMBATlite
     integer                                 :: ichl
     real                                    :: par_phy_mldsum, par_z_mldsum
     real                                    :: chl, zchl, zval, phy_chlc
-    real                                    :: phy_k_nit, phy_k_fer
     real                                    :: phy_pisl, phy_pisl2 
     real                                    :: pchl_pisl, pchl_lpar, pchl_mumin, pchl_muopt
     real, dimension(:,:), allocatable       :: ek_bgr, par_bgr_mid, par_bgr_top
@@ -1730,7 +1769,7 @@ module generic_WOMBATlite
     real                                    :: fesol1, fesol2, fesol3, fesol4, fesol5, hp, fe3sol
     real                                    :: biof, biodoc
     real                                    :: phy_Fe2C, zoo_Fe2C, det_Fe2C
-    real                                    :: phy_minqfe, phy_maxqfe, phy_dFeupt_upreg, phy_dFeupt_doreg
+    real                                    :: phy_minqfe, phy_maxqfe
     real                                    :: zoo_slmor
     logical                                 :: used
 
@@ -1919,9 +1958,11 @@ module generic_WOMBATlite
     wombat%phy_mumax(:,:,:) = 0.0
     wombat%phy_mu(:,:,:) = 0.0
     wombat%pchl_mu(:,:,:) = 0.0
-    wombat%phy_lpar(:,:,:) = 1.0
-    wombat%phy_lnit(:,:,:) = 1.0
-    wombat%phy_lfer(:,:,:) = 1.0
+    wombat%phy_kni(:,:,:) = 0.0
+    wombat%phy_kfe(:,:,:) = 0.0
+    wombat%phy_lpar(:,:,:) = 0.0
+    wombat%phy_lnit(:,:,:) = 0.0
+    wombat%phy_lfer(:,:,:) = 0.0
     wombat%phy_dfeupt(:,:,:) = 0.0
     wombat%feIII(:,:,:) = 0.0
     wombat%felig(:,:,:) = 0.0
@@ -1932,6 +1973,8 @@ module generic_WOMBATlite
     wombat%fesources(:,:,:) = 0.0
     wombat%fesinks(:,:,:) = 0.0
     wombat%fecoag2det(:,:,:) = 0.0
+    wombat%phy_feupreg(:,:,:) = 0.0
+    wombat%phy_fedoreg(:,:,:) = 0.0
     wombat%phygrow(:,:,:) = 0.0
     wombat%phyresp(:,:,:) = 0.0
     wombat%phymort(:,:,:) = 0.0
@@ -1940,6 +1983,7 @@ module generic_WOMBATlite
     wombat%zoomort(:,:,:) = 0.0
     wombat%zooexcr(:,:,:) = 0.0
     wombat%zooslop(:,:,:) = 0.0
+    wombat%reminr(:,:,:) = 0.0
     wombat%detremi(:,:,:) = 0.0
     wombat%caldiss(:,:,:) = 0.0
     wombat%export_prod(:,:) = 0.0
@@ -2125,7 +2169,7 @@ module generic_WOMBATlite
 
         if (swpar.gt.0.0) then
           ! Euphotic zone
-          if (par_mid(k).gt.(swpar*0.01) .and. par_mid(k).gt.1.0) then
+          if (par_mid(k).gt.(swpar*0.01) .and. par_mid(k).gt.0.01) then
             wombat%zeuphot(i,j) = wombat%zw(i,j,k)
           endif
           ! Light attenuation mean over the grid cells (Eq. 19 of Baird et al., 2020 GMD)
@@ -2151,7 +2195,8 @@ module generic_WOMBATlite
       enddo !}
 
       ! Calculate impact of euphotic zone depth on phytoplankton and chlorophyll production
-      wombat%phy_leup(i,j) = MIN(1.0, wombat%zeuphot(i,j)/(hblt_depth(i,j) + epsi))
+!      wombat%phy_leup(i,j) = MIN(1.0, wombat%zeuphot(i,j)/(hblt_depth(i,j) + epsi))
+       wombat%phy_leup(i,j) = 1.0
 
       !--- Aggregate light in mixed layer and calculate maximum growth rates ---!
       do k = 1,grid_kmt(i,j)  !{
@@ -2199,6 +2244,7 @@ module generic_WOMBATlite
 
       ! Initialise some values and ratios (put into nicer units than mol/kg)
       biophy   = max(epsi, wombat%f_phy(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
+      biophy1  = max(epsi, wombat%f_phy(i,j,1) ) / mmol_m3_to_mol_kg  ![mmol/m3]
       biophyfe = max(epsi, wombat%f_phyfe(i,j,k))/ mmol_m3_to_mol_kg  ![mmol/m3]
       biozoo   = max(epsi, wombat%f_zoo(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
       biodet   = max(epsi, wombat%f_det(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
@@ -2222,29 +2268,38 @@ module generic_WOMBATlite
       ! 1. Allometric scaling of 0.37 (Wickman et al., 2024; Science)
       ! 2. Apply variable K to set limitation term
 
-      phy_k_nit = wombat%phykn * max(biophy, 0.1)**(0.37)
-      phy_k_fer = wombat%phykf * max(biophy, 0.1)**(0.37)
+      wombat%phy_kni(i,j,k) = wombat%phykn * max(0.1, max(0.0, (biophy-wombat%phybiot))**0.37)
+      wombat%phy_kfe(i,j,k) = wombat%phykf * max(0.5, max(0.0, (biophy-wombat%phybiot))**0.37)
       ! Nitrogen limitation (currently Michaelis-Menten term)
-      wombat%phy_lnit(i,j,k) = biono3 / (biono3 + phy_k_nit + epsi)
+      wombat%phy_lnit(i,j,k) = biono3 / (biono3 + wombat%phy_kni(i,j,k))
       ! Iron limitation (Quota model, constants from Flynn & Hipkin 1999)
-      if (biophy.gt.1e-3) then
-        phy_minqfe = 0.00167 / 55.85 * phy_chlc + &
-                     1.21e-5 * 14.0 / 55.85 / 7.625 * 0.5 * 1.5 * wombat%phy_lnit(i,j,k) + &
-                     1.15e-4 * 14.0 / 55.85 / 7.625 * 0.5 * wombat%phy_lnit(i,j,k)
-        wombat%phy_lfer(i,j,k) = min(1.0, max(0.0, (phy_Fe2C - phy_minqfe) / wombat%phyoptqf ))
-      endif
+      phy_minqfe = 0.00167 / 55.85 * max(wombat%phyminqc, phy_chlc)*12 + &
+                   1.21e-5 * 14.0 / 55.85 / 7.625 * 0.5 * 1.5 * wombat%phy_lnit(i,j,k) + &
+                   1.15e-4 * 14.0 / 55.85 / 7.625 * 0.5 * wombat%phy_lnit(i,j,k)
+      wombat%phy_lfer(i,j,k) = min(1.0, max(0.0, (phy_Fe2C - phy_minqfe) / wombat%phyoptqf ))
 
 
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
-      !  [Step 3] Temperature-dependence of heterotrophy                      !
+      !  [Step 3] Heterotrophy and remineralisation                           !
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
 
-      ! Temperature dependance of heterotrophy
+      ! Temperature dependance of heterotrophy (applies to bact and zoo)
       fbc = wombat%bbioh ** (Temp(i,j,k))
+
+      ! Variable rates of remineralisation
+      !   We set the rate of remineralisation to be variable to emulate variations
+      !   in the sinking speeds of detritus, which in MOM must be constant.
+      !   Thus, we (1) increase remineralisation in the gyres where bacterial
+      !   recycling of material is rapid and where large quantities of suspended
+      !   organics exist, and (2) decrease remineralisation with depth to 
+      !   account for the power-law behaviour of POC in the water column
+      wombat%reminr(i,j,k) = wombat%detlrem * fbc * &
+                             min(2.0, (wombat%phybiot / biophy1)**0.21) * &
+                             max(0.25, (1. - wombat%zm(i,j,k) / 5000.0))
 
 
       !-----------------------------------------------------------------------!
@@ -2266,6 +2321,7 @@ module generic_WOMBATlite
       wombat%phy_mu(i,j,k) = wombat%phy_mumax(i,j,k) * wombat%phy_lpar(i,j,k) * & 
                              min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))
 
+
       ! Save the average light limitation over the euphotic zone
       if (wombat%zw(i,j,k) .le. wombat%zeuphot(i,j)) then 
         wombat%light_limit(i,j) = wombat%light_limit(i,j) + dzt(i,j,k) &
@@ -2284,10 +2340,9 @@ module generic_WOMBATlite
       ! 1. Light limitation of chlorophyll production
       ! 2. minimum and optimal rates of chlorophyll growth
       ! 3. Calculate mg Chl m-3 s-1
-      
+     
       pchl_pisl = phy_pisl / ( wombat%phy_mumax(i,j,k) * 86400.0 * & 
-                               (1. - min(wombat%phy_lnit(i,j,k), &
-                                         wombat%phy_lfer(i,j,k))) + epsi )
+                  (1. - min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))) + epsi )
       pchl_lpar = (1. - exp(-pchl_pisl * par_phymld(i,j,k))) * wombat%phy_leup(i,j)
       pchl_mumin = wombat%phyminqc * wombat%phy_mu(i,j,k) * biophy * 12.0   ![mg/m3/s] 
       pchl_muopt = wombat%phyoptqc * wombat%phy_mu(i,j,k) * biophy * 12.0   ![mg/m3/s]
@@ -2312,14 +2367,15 @@ module generic_WOMBATlite
       ! 2. Ensure that dFe uptake increases or decreases in response to cell quota
       ! 3. Iron uptake of phytoplankton
 
-      phy_maxqfe = biophy * wombat%phymaxqf
-      phy_dFeupt_upreg = (4.0 - 4.5 * wombat%phy_lfer(i,j,k) / &
-                          (wombat%phy_lfer(i,j,k) + 0.5) )
-      phy_dFeupt_doreg = max(0.0, (1.0 - biophyfe/phy_maxqfe) / &
+      phy_maxqfe = biophy * wombat%phymaxqf  !mmol Fe / m3
+      wombat%phy_feupreg(i,j,k) = (4.0 - 4.5 * wombat%phy_lfer(i,j,k) / &
+                                  (wombat%phy_lfer(i,j,k) + 0.5) )
+      wombat%phy_fedoreg(i,j,k) = max(0.0, (1.0 - biophyfe/phy_maxqfe) / &
                                   abs(1.05 - biophyfe/phy_maxqfe) )
       wombat%phy_dfeupt(i,j,k) = (biophy * wombat%phy_mumax(i,j,k) * wombat%phymaxqf * &
-                                  biofer / (biofer + phy_k_fer) * &
-                                  phy_dFeupt_doreg * phy_dFeupt_upreg) * mmol_m3_to_mol_kg
+                                  biofer / (biofer + wombat%phy_kfe(i,j,k)) * &
+                                  wombat%phy_feupreg(i,j,k) * &
+                                  wombat%phy_fedoreg(i,j,k)) * mmol_m3_to_mol_kg
 
 
       !-----------------------------------------------------------------------!
@@ -2338,11 +2394,13 @@ module generic_WOMBATlite
       fesol3 = 10**(0.4511 - 0.3305*zval**0.5 - 1996.0/ztemk)
       fesol4 = 10**(-0.2965 - 0.7881*zval**0.5 - 4086.0/ztemk)
       fesol5 = 10**(4.4466 - 0.8505*zval**0.5 - 7980.0/ztemk)
-      hp = wombat%ahtotal(i,j,k)
+      hp = 10**(-7.9)
+      if (wombat%ahtotal(i,j,k).gt.0.0) hp = wombat%ahtotal(i,j,k)
       fe3sol = fesol1 * ( hp**3 + fesol2 * hp**2 + fesol3 * hp + fesol4 + fesol5 / hp ) *1e9
 
       ! Estimate total colloidal iron
-      ! ... for now, we assume that 50% of all dFe is colloidal
+      ! ... for now, we assume that 50% of all dFe is colloidal, and we separate this from the 
+      !     equilibrium fractionation between Fe' and Fe-L below
       wombat%fecol(i,j,k) = 0.5 * biofer 
 
       ! Determine equilibriuim fractionation of the remain dFe (non-colloidal fraction) into Fe' and L-Fe
@@ -2360,7 +2418,7 @@ module generic_WOMBATlite
 
       ! Scavenging of Fe` onto biogenic particles 
       partic = (biodet + biocaco3)
-      wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (3e-5 + wombat%kscav_dfe * partic) / 86400.0
+      wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (3e-8 + wombat%kscav_dfe * partic) / 86400.0
       wombat%fescadet(i,j,k) = wombat%fescaven(i,j,k) * biodet / (partic+epsi) 
 
       ! Coagulation of colloidal Fe (umol/m3) to form sinking particles (mmol/m3)
@@ -2368,17 +2426,20 @@ module generic_WOMBATlite
       biof = max(1/3., biophy / (biophy + 0.03))
       biodoc = 2.0 + (1.0 - min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))) * 38.0 ! proxy of DOC (mmol/m3)
       if (wombat%zw(i,j,k).le.hblt_depth(i,j)) then
-        zval = (      (12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-8
+        zval = (      (12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-9
       else
-        zval = ( 0.01*(12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-8
+        zval = ( 0.01*(12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-9
       endif
       wombat%fecoag2det(i,j,k) = wombat%fecol(i,j,k) * zval / 86400.0
 
-      ! Convert the sink terms to mol/kg
-      wombat%feprecip(i,j,k) = wombat%feprecip(i,j,k) * umol_m3_to_mol_kg
-      wombat%fescaven(i,j,k) = wombat%fescaven(i,j,k) * umol_m3_to_mol_kg
-      wombat%fescadet(i,j,k) = wombat%fescadet(i,j,k) * umol_m3_to_mol_kg
-      wombat%fecoag2det(i,j,k) = wombat%fecoag2det(i,j,k) * umol_m3_to_mol_kg
+      ! Convert the terms back to mol/kg
+      wombat%feprecip(i,j,k) = wombat%feprecip(i,j,k) * umol_m3_to_mol_kg 
+      wombat%fescaven(i,j,k) = wombat%fescaven(i,j,k) * umol_m3_to_mol_kg * 0.0
+      wombat%fescadet(i,j,k) = wombat%fescadet(i,j,k) * umol_m3_to_mol_kg * 0.0
+      wombat%fecoag2det(i,j,k) = wombat%fecoag2det(i,j,k) * umol_m3_to_mol_kg * 0.0
+      wombat%feIII(i,j,k) = wombat%feIII(i,j,k) * umol_m3_to_mol_kg
+      wombat%felig(i,j,k) = wombat%felig(i,j,k) * umol_m3_to_mol_kg
+      wombat%fecol(i,j,k) = wombat%fecol(i,j,k) * umol_m3_to_mol_kg
 
 
       !-----------------------------------------------------------------------!
@@ -2419,8 +2480,8 @@ module generic_WOMBATlite
         wombat%phyresp(i,j,k) = 0.0
         wombat%phymort(i,j,k) = 0.0
       endif
-        wombat%zooexcr(i,j,k) = wombat%zoograz(i,j,k) * (1.0 - wombat%zooassi)*0.75
-        wombat%zooslop(i,j,k) = wombat%zoograz(i,j,k) * (1.0 - wombat%zooassi)*0.25
+      wombat%zooexcr(i,j,k) = wombat%zoograz(i,j,k) * (1.0 - wombat%zooassi)*0.75
+      wombat%zooslop(i,j,k) = wombat%zoograz(i,j,k) * (1.0 - wombat%zooassi)*0.25
       
       if (biozoo .gt. 1e-3) then
         wombat%zooresp(i,j,k) = wombat%zoolmor * fbc * wombat%f_zoo(i,j,k) * zoo_slmor ! [molC/kg/s]
@@ -2431,7 +2492,7 @@ module generic_WOMBATlite
       endif
       
       if (wombat%f_det(i,j,k) .gt. epsi) then
-        wombat%detremi(i,j,k) = wombat%detlrem * fbc * wombat%f_det(i,j,k) ! [molC/kg/s]
+        wombat%detremi(i,j,k) = wombat%reminr(i,j,k) * wombat%f_det(i,j,k) ! [molC/kg/s]
         if (wombat%zw(i,j,k) .ge. 180.0) wombat%detremi(i,j,k) = 0.5 * wombat%detremi(i,j,k) ! reduce decay below 180m
       else
         wombat%detremi(i,j,k) = 0.0
@@ -2559,16 +2620,29 @@ module generic_WOMBATlite
                              wombat%fecoag2det(i,j,k) )
 
       ! Collect dFe sources and sinks for diagnostic output
-      wombat%fesources(i,j,k) = wombat%fesources(i,j,k) + dtsb*rdtts * ( &
+      wombat%fesources(i,j,k) = wombat%fesources(i,j,k) + dtsb * ( &
                                   wombat%detremi(i,j,k) * det_Fe2C + &
                                   wombat%zooresp(i,j,k) * zoo_Fe2C + &
                                   wombat%zooexcr(i,j,k) * zoo_Fe2C + &
                                   wombat%phyresp(i,j,k) * phy_Fe2C)
-      wombat%fesinks(i,j,k) = wombat%fesinks(i,j,k) + dtsb*rdtts * ( & 
+      wombat%fesinks(i,j,k) = wombat%fesinks(i,j,k) + dtsb * ( & 
                                 wombat%phy_dfeupt(i,j,k) + &
                                 wombat%feprecip(i,j,k) + &
                                 wombat%fescaven(i,j,k) + &
                                 wombat%fecoag2det(i,j,k)) 
+
+      if (i.eq.150 .and. j.eq.180 .and. k.lt.25) then
+        print*, k, wombat%zm(i,j,k), wombat%f_fe(i,j,k)
+        print*, wombat%feIII(i,j,k), wombat%felig(i,j,k), wombat%fecol(i,j,k)
+        print*, "Fe Sources", wombat%fesources(i,j,k) * rdtts * ts_npzd/tn
+        print*, wombat%detremi(i,j,k)* det_Fe2C
+        print*, wombat%zooresp(i,j,k)*zoo_Fe2C, wombat%zooexcr(i,j,k)*zoo_Fe2C
+        print*, wombat%phyresp(i,j,k)* phy_Fe2C
+        print*, "Fe Sinks", wombat%fesinks(i,j,k) * rdtts * ts_npzd/tn
+        print*, wombat%phy_dfeupt(i,j,k), wombat%feprecip(i,j,k)
+        print*, wombat%fescaven(i,j,k), wombat%fecoag2det(i,j,k)
+        print*, " " 
+      endif
 
       enddo; enddo; enddo
     enddo
@@ -2596,6 +2670,8 @@ module generic_WOMBATlite
       wombat%pprod_gross(i,j,k) = rdtts * wombat%pprod_gross(i,j,k) * grid_tmask(i,j,k) ! [mol/kg/s]
       wombat%zprod_gross(i,j,k) = rdtts * wombat%zprod_gross(i,j,k) * grid_tmask(i,j,k) ! [mol/kg/s]
       wombat%npp3d(i,j,k) = rdtts * wombat%npp3d(i,j,k) * grid_tmask(i,j,k) ! [mol/kg/s]
+      wombat%fesources(i,j,k) = rdtts * wombat%fesources(i,j,k) * grid_tmask(i,j,k) ! [mol/kg/s]
+      wombat%fesinks(i,j,k) = rdtts * wombat%fesinks(i,j,k) * grid_tmask(i,j,k) ! [mol/kg/s]
 
       if (wombat%zw(i,j,k) .le. hblt_depth(i,j)) then
         wombat%adic_intmld(i,j) = wombat%adic_intmld(i,j) + &
@@ -2763,6 +2839,14 @@ module generic_WOMBATlite
       used = g_send_data(wombat%id_pchl_mu, wombat%pchl_mu, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
+    if (wombat%id_phy_kni .gt. 0) &
+      used = g_send_data(wombat%id_phy_kni, wombat%phy_kni, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_phy_kfe .gt. 0) &
+      used = g_send_data(wombat%id_phy_kfe, wombat%phy_kfe, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
     if (wombat%id_phy_lpar .gt. 0) &
       used = g_send_data(wombat%id_phy_lpar, wombat%phy_lpar, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
@@ -2815,6 +2899,14 @@ module generic_WOMBATlite
       used = g_send_data(wombat%id_fesinks, wombat%fesinks, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
+    if (wombat%id_phy_feupreg .gt. 0) &
+      used = g_send_data(wombat%id_phy_feupreg, wombat%phy_feupreg, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_phy_fedoreg .gt. 0) &
+      used = g_send_data(wombat%id_phy_fedoreg, wombat%phy_fedoreg, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
     if (wombat%id_phygrow .gt. 0) &
       used = g_send_data(wombat%id_phygrow, wombat%phygrow, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
@@ -2845,6 +2937,10 @@ module generic_WOMBATlite
 
     if (wombat%id_zooslop .gt. 0) &
       used = g_send_data(wombat%id_zooslop, wombat%zooslop, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_reminr .gt. 0) &
+      used = g_send_data(wombat%id_reminr, wombat%reminr, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
     if (wombat%id_detremi .gt. 0) &
@@ -3324,6 +3420,8 @@ module generic_WOMBATlite
     allocate(wombat%phy_mumax(isd:ied, jsd:jed, 1:nk)); wombat%phy_mumax(:,:,:)=0.0
     allocate(wombat%phy_mu(isd:ied, jsd:jed, 1:nk)); wombat%phy_mu(:,:,:)=0.0
     allocate(wombat%pchl_mu(isd:ied, jsd:jed, 1:nk)); wombat%pchl_mu(:,:,:)=0.0
+    allocate(wombat%phy_kni(isd:ied, jsd:jed, 1:nk)); wombat%phy_kni(:,:,:)=0.0
+    allocate(wombat%phy_kfe(isd:ied, jsd:jed, 1:nk)); wombat%phy_kfe(:,:,:)=0.0
     allocate(wombat%phy_lpar(isd:ied, jsd:jed, 1:nk)); wombat%phy_lpar(:,:,:)=0.0
     allocate(wombat%phy_lnit(isd:ied, jsd:jed, 1:nk)); wombat%phy_lnit(:,:,:)=0.0
     allocate(wombat%phy_lfer(isd:ied, jsd:jed, 1:nk)); wombat%phy_lfer(:,:,:)=0.0
@@ -3337,6 +3435,8 @@ module generic_WOMBATlite
     allocate(wombat%fecoag2det(isd:ied, jsd:jed, 1:nk)); wombat%fecoag2det(:,:,:)=0.0
     allocate(wombat%fesources(isd:ied, jsd:jed, 1:nk)); wombat%fesources(:,:,:)=0.0
     allocate(wombat%fesinks(isd:ied, jsd:jed, 1:nk)); wombat%fesinks(:,:,:)=0.0
+    allocate(wombat%phy_feupreg(isd:ied, jsd:jed, 1:nk)); wombat%phy_feupreg(:,:,:)=0.0
+    allocate(wombat%phy_fedoreg(isd:ied, jsd:jed, 1:nk)); wombat%phy_fedoreg(:,:,:)=0.0
     allocate(wombat%phygrow(isd:ied, jsd:jed, 1:nk)); wombat%phygrow(:,:,:)=0.0
     allocate(wombat%phyresp(isd:ied, jsd:jed, 1:nk)); wombat%phyresp(:,:,:)=0.0
     allocate(wombat%phymort(isd:ied, jsd:jed, 1:nk)); wombat%phymort(:,:,:)=0.0
@@ -3345,6 +3445,7 @@ module generic_WOMBATlite
     allocate(wombat%zoomort(isd:ied, jsd:jed, 1:nk)); wombat%zoomort(:,:,:)=0.0
     allocate(wombat%zooexcr(isd:ied, jsd:jed, 1:nk)); wombat%zooexcr(:,:,:)=0.0
     allocate(wombat%zooslop(isd:ied, jsd:jed, 1:nk)); wombat%zooslop(:,:,:)=0.0
+    allocate(wombat%reminr(isd:ied, jsd:jed, 1:nk)); wombat%reminr(:,:,:)=0.0
     allocate(wombat%detremi(isd:ied, jsd:jed, 1:nk)); wombat%detremi(:,:,:)=0.0
     allocate(wombat%caldiss(isd:ied, jsd:jed, 1:nk)); wombat%caldiss(:,:,:)=0.0
     allocate(wombat%no3_prev(isd:ied, jsd:jed, 1:nk)); wombat%no3_prev(:,:,:)=0.0
@@ -3454,6 +3555,8 @@ module generic_WOMBATlite
         wombat%phy_mumax, &
         wombat%phy_mu, &
         wombat%pchl_mu, &
+        wombat%phy_kni, &
+        wombat%phy_kfe, &
         wombat%phy_lpar, &
         wombat%phy_lnit, &
         wombat%phy_lfer, &
@@ -3467,6 +3570,8 @@ module generic_WOMBATlite
         wombat%fecoag2det, &
         wombat%fesources, &
         wombat%fesinks, &
+        wombat%phy_feupreg, &
+        wombat%phy_fedoreg, &
         wombat%phygrow, &
         wombat%phyresp, &
         wombat%phymort, &
@@ -3475,6 +3580,7 @@ module generic_WOMBATlite
         wombat%zoomort, &
         wombat%zooexcr, &
         wombat%zooslop, &
+        wombat%reminr, &
         wombat%detremi, &
         wombat%caldiss, &
         wombat%no3_prev, &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2712,7 +2712,7 @@ module generic_WOMBATlite
         diss_cal = (wombat%disscal * max(0.0, 1.0 - wombat%omega_cal(i,j,k))**2.2) / 86400.0
         diss_ara = (wombat%dissara * max(0.0, 1.0 - wombat%omega_ara(i,j,k))**1.5) / 86400.0
         diss_det = (wombat%dissdet * wombat%reminr(i,j,k) * biodet**2.0)
-        wombat%dissrat(i,j,k) = wombat%caco3lrem*0.25 + diss_cal + diss_ara + diss_det
+        wombat%dissrat(i,j,k) = diss_cal + diss_ara + diss_det
 
       else
       
@@ -3129,11 +3129,11 @@ module generic_WOMBATlite
         wsink(:) = wombat%wdetbio * max(0.0, biophy1 - wombat%phybiot)**(0.21) 
         do k=1,nk
           wsink(k) = wsink(k) + 10.0/86400.0 * min(1.0, & 
-                                (wombat%f_caco3(i,j,k) / (wombat%f_det(i,j,k) + wombat%f_caco3(i,j,k))))
+                     (wombat%f_caco3(i,j,k) / (wombat%f_det(i,j,k) + wombat%f_caco3(i,j,k) + epsi)))
           ! Increase sinking rate with depth to achieve power law behaviour  
           wsink(k) = wsink(k) + max(0.0, wombat%zw(i,j,k)/5000.0 * (wombat%wdetmax - wsink(k)))
           ! Ensure that we don't violate the CFL criterion  
-          max_wsink = dzt(i,j,k) * 0.5 / dt  ! [m/s]
+          max_wsink = dzt(i,j,k) * 0.5 / (dt * 2)  ! [m/s]
           wsink(k) = min(wsink(k), max_wsink)
           ! CaCO3 sinks slower than general detritus because it tends to be smaller
           wsinkcal(k) = wsink(k) * wombat%wcaco3/wombat%wdetbio

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -3128,7 +3128,8 @@ module generic_WOMBATlite
         biophy1  = max(epsi, wombat%f_phy(i,j,1) ) / mmol_m3_to_mol_kg  ![mmol/m3]
         wsink(:) = wombat%wdetbio * max(0.0, biophy1 - wombat%phybiot)**(0.21) 
         do k=1,nk
-          !wsink(k) = wsink(k) + 10.0/86400.0 * min(1.0, (wombat%f_caco3(i,j,k) / (wombat%f_det(i,j,k) + epsi)))
+          wsink(k) = wsink(k) + 10.0/86400.0 * min(1.0, & 
+                                (wombat%f_caco3(i,j,k) / (wombat%f_det(i,j,k) + wombat%f_caco3(i,j,k))))
           ! Increase sinking rate with depth to achieve power law behaviour  
           wsink(k) = wsink(k) + max(0.0, wombat%zw(i,j,k)/5000.0 * (wombat%wdetmax - wsink(k)))
           ! Ensure that we don't violate the CFL criterion  

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -168,6 +168,7 @@ module generic_WOMBATlite
         dic_min, &
         dic_max, &
         alk_min, &
+        alk_max, &
         htotal_scale_lo, &
         htotal_scale_hi, &
         htotal_in, &
@@ -1173,17 +1174,21 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------
     call g_tracer_add_param('htotal_scale_hi', wombat%htotal_scale_hi, 100.0)
 
-    ! Absolute minimum of dissolved inorganic carbon [mmol/m3]
+    ! Absolute minimum of dissolved inorganic carbon [mmol/m3] for co2 sys calcs
     !-----------------------------------------------------------------------
     call g_tracer_add_param('dic_min', wombat%dic_min, 1000.0)
 
-    ! Absolute maximum of dissolved inorganic carbon [mmol/m3]
+    ! Absolute maximum of dissolved inorganic carbon [mmol/m3] for co2 sys calcs
     !-----------------------------------------------------------------------
     call g_tracer_add_param('dic_max', wombat%dic_max, 3000.0)
 
-    ! Absolute minimum of alkalinity [mmol/m3]
+    ! Absolute minimum of alkalinity [mmol/m3] for co2 sys calcs
     !-----------------------------------------------------------------------
     call g_tracer_add_param('alk_min', wombat%alk_min, 1000.0)
+
+    ! Absolute maximum of alkalinity [mmol/m3] for co2 sys calcs
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('alk_max', wombat%alk_max, 3000.0)
 
     ! Global average surface concentration of inorganic silicate [mol/kg]
     !-----------------------------------------------------------------------
@@ -1239,7 +1244,7 @@ module generic_WOMBATlite
 
     ! Phytoplankton linear mortality rate constant [1/s]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('phylmor', wombat%phylmor, 0.01/86400.0)
+    call g_tracer_add_param('phylmor', wombat%phylmor, 0.005/86400.0)
 
     ! Phytoplankton quadratic mortality rate constant [m3/mmolN/s]
     !-----------------------------------------------------------------------
@@ -1247,7 +1252,7 @@ module generic_WOMBATlite
 
     ! Zooplankton assimilation efficiency [1]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('zooassi', wombat%zooassi, 0.6)
+    call g_tracer_add_param('zooassi', wombat%zooassi, 0.5)
 
     ! Zooplankton half saturation coefficient for linear mortality
     !-----------------------------------------------------------------------
@@ -1322,15 +1327,15 @@ module generic_WOMBATlite
 
     ! Background concentration of iron-binding ligand [umol/m3]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('ligand', wombat%ligand, 0.7)
+    call g_tracer_add_param('ligand', wombat%ligand, 0.6)
 
     ! Precipitation of Fe` as nanoparticles (in excess of solubility) [/d]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('knano_dfe', wombat%knano_dfe, 0.01)
+    call g_tracer_add_param('knano_dfe', wombat%knano_dfe, 0.1)
 
     ! Scavenging of Fe` onto biogenic particles [(mmolC/m3)-1 d-1]
     !-----------------------------------------------------------------------
-    call g_tracer_add_param('kscav_dfe', wombat%kscav_dfe, 5e-3)
+    call g_tracer_add_param('kscav_dfe', wombat%kscav_dfe, 5e-2)
 
     ! Nested timestep for the ecosystem model [s]
     !-----------------------------------------------------------------------
@@ -1983,7 +1988,7 @@ module generic_WOMBATlite
            min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_dic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
            max(wombat%f_no3(:,:,k) / 16., 1e-9), &
            wombat%sio2(:,:), &
-           max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg), &
+           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
            wombat%htotallo(:,:), wombat%htotalhi(:,:), &
            wombat%htotal(:,:,k), &
            co2_calc=trim(co2_calc), &
@@ -1996,7 +2001,7 @@ module generic_WOMBATlite
            min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_adic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
            max(wombat%f_no3(:,:,k) / 16., 1e-9), &
            wombat%sio2(:,:), &
-           max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg), &
+           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
            wombat%ahtotallo(:,:), wombat%ahtotalhi(:,:), &
            wombat%ahtotal(:,:,k), &
            co2_calc=trim(co2_calc), &
@@ -2016,7 +2021,7 @@ module generic_WOMBATlite
            min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_dic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
            max(wombat%f_no3(:,:,k) / 16., 1e-9), &
            wombat%sio2(:,:), &
-           max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg), &
+           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
            wombat%htotallo(:,:), wombat%htotalhi(:,:), &
            wombat%htotal(:,:,k), &
            co2_calc=trim(co2_calc), &
@@ -2027,7 +2032,7 @@ module generic_WOMBATlite
            min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_adic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
            max(wombat%f_no3(:,:,k) / 16., 1e-9), &
            wombat%sio2(:,:), &
-           max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg), &
+           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
            wombat%ahtotallo(:,:), wombat%ahtotalhi(:,:), &
            wombat%ahtotal(:,:,k), &
            co2_calc=trim(co2_calc), &
@@ -2500,7 +2505,7 @@ module generic_WOMBATlite
 
       ! Scavenging of Fe` onto biogenic particles 
       partic = (biodet + biocaco3)
-      wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (3e-8 + wombat%kscav_dfe * partic) / 86400.0
+      wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (1e-7 + wombat%kscav_dfe * partic) / 86400.0
       wombat%fescadet(i,j,k) = wombat%fescaven(i,j,k) * biodet / (partic+epsi) 
 
       ! Coagulation of colloidal Fe (umol/m3) to form sinking particles (mmol/m3)
@@ -2508,9 +2513,9 @@ module generic_WOMBATlite
       biof = max(1/3., biophy / (biophy + 0.03))
       biodoc = 2.0 + (1.0 - min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))) * 38.0 ! proxy of DOC (mmol/m3)
       if (wombat%zw(i,j,k).le.hblt_depth(i,j)) then
-        zval = (      (12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-9
+        zval = (      (12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-6
       else
-        zval = ( 0.01*(12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-9
+        zval = ( 0.01*(12.*biof*biodoc + 9.*biodet) + 2.5*biodet + 128.*biof*biodoc + 725.*biodet )*1e-6
       endif
       wombat%fecoag2det(i,j,k) = wombat%fecol(i,j,k) * zval / 86400.0
 
@@ -2543,7 +2548,7 @@ module generic_WOMBATlite
       epsmin = wombat%zooepsmin * ( 1.5 * tanh(0.2*(Temp(i,j,k)-15.0)) + 2.5 )
       wombat%zooeps(i,j,k) = epsmin + (wombat%zooepsmax - epsmin) / &
                                       (1. + exp(3.*(biophy - 2.*wombat%phybiot))) / &
-                                      (1. + exp(-(Temp(i,j,k)-15.0)))
+                                      (1. + exp(-(Temp(i,j,k)-10.0)))
       g_npz = wombat%zoogmax * fbc * (wombat%zooeps(i,j,k) * zooprey*zooprey) / &
               (wombat%zoogmax * fbc + (wombat%zooeps(i,j,k) * zooprey*zooprey))
 
@@ -2591,8 +2596,8 @@ module generic_WOMBATlite
       endif
       
       if (wombat%f_det(i,j,k) .gt. epsi) then
-        wombat%detremi(i,j,k) = wombat%reminr(i,j,k) * wombat%f_det(i,j,k) ! [molC/kg/s]
-        if (wombat%zw(i,j,k) .ge. 180.0) wombat%detremi(i,j,k) = wombat%detremi(i,j,k) * 0.5
+        wombat%detremi(i,j,k) = wombat%reminr(i,j,k) / mmol_m3_to_mol_kg * wombat%f_det(i,j,k)**2.0 ! [molC/kg/s]
+        !if (wombat%zw(i,j,k) .ge. 180.0) wombat%detremi(i,j,k) = wombat%detremi(i,j,k) * 0.5
       else
         wombat%detremi(i,j,k) = 0.0
       endif
@@ -2914,7 +2919,7 @@ module generic_WOMBATlite
         !       this is essential for ensuring dFe is replenished in upper ocean and actually
         !       looks to be the secret of PISCES ability to replicate dFe limitation in the right places
         zno3 = wombat%f_no3(i,j,k) / mmol_m3_to_mol_kg
-        zfermin = min( max( 3e-2 * zno3 * zno3, 5e-3), 7e-2) * umol_m3_to_mol_kg
+        zfermin = min( max( 3e-2 * zno3 * zno3, 5e-2), 7e-2) * umol_m3_to_mol_kg
         wombat%f_fe(i,j,k) = max(zfermin, wombat%f_fe(i,j,k)) * grid_tmask(i,j,k)
         ! pjb: set limits of some tracers and save corrections to output for budgets
         wombat%alk_correct(i,j,k) = (max(wombat%alk_min * mmol_m3_to_mol_kg, wombat%f_alk(i,j,k) ) &
@@ -2971,7 +2976,7 @@ module generic_WOMBATlite
     enddo; enddo
 
     !-----------------------------------------------------------------------
-    ! Remineralisation of sediment tracers
+    ! Remineralisation and burial of sediment tracers
     !-----------------------------------------------------------------------
     call g_tracer_get_pointer(tracer_list, 'det_sediment', 'field', wombat%p_det_sediment) ! [mol/m2]
     call g_tracer_get_pointer(tracer_list, 'detfe_sediment', 'field', wombat%p_detfe_sediment) ! [mol/m2]
@@ -2993,6 +2998,7 @@ module generic_WOMBATlite
         wombat%b_adic(i,j) = wombat%b_dic(i,j) ! [mol/m2/s]
         wombat%b_fe(i,j) = -1.0 * wombat%detfe_sed_remin(i,j) ! [mol/m2/s]
         wombat%b_alk(i,j) = -2.0 * wombat%caco3_sed_remin(i,j) - wombat%b_no3(i,j) ! [mol/m2/s]
+
       endif
     enddo; enddo
 
@@ -3481,7 +3487,7 @@ module generic_WOMBATlite
           min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_dic(:,:,1), wombat%dic_min*mmol_m3_to_mol_kg)), &
           max(wombat%f_no3(:,:,1) / 16., 1e-9), &
           wombat%sio2(:,:), &
-          max(wombat%f_alk(:,:,1), wombat%alk_min*mmol_m3_to_mol_kg), &
+          min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,1), wombat%alk_min*mmol_m3_to_mol_kg)), &
           wombat%htotallo(:,:), wombat%htotalhi(:,:), &
           wombat%htotal(:,:,1), &
           co2_calc=trim(co2_calc), &
@@ -3494,7 +3500,7 @@ module generic_WOMBATlite
           min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_adic(:,:,1), wombat%dic_min*mmol_m3_to_mol_kg)), &
           max(wombat%f_no3(:,:,1) / 16., 1e-9), &
           wombat%sio2(:,:), &
-          max(wombat%f_alk(:,:,1), wombat%alk_min*mmol_m3_to_mol_kg), &
+          min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,1), wombat%alk_min*mmol_m3_to_mol_kg)), &
           wombat%ahtotallo(:,:), wombat%ahtotalhi(:,:), &
           wombat%ahtotal(:,:,1), &
           co2_calc=trim(co2_calc), &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1633,7 +1633,6 @@ module generic_WOMBATlite
         units = 'mol/kg', &
         prog = .true., &
         move_vertical = .true., &
-        flux_bottom = .false., &
         btm_reservoir = .true.)
 
     ! Detrital iron content
@@ -1644,7 +1643,6 @@ module generic_WOMBATlite
         units = 'mol/kg', &
         prog = .true., &
         move_vertical = .true., &
-        flux_bottom = .false., &
         btm_reservoir = .true.)
 
     ! CaCO3
@@ -1655,7 +1653,6 @@ module generic_WOMBATlite
         units = 'mol/kg', &
         prog = .true., &
         move_vertical = .true., &
-        flux_bottom = .false., &
         btm_reservoir = .true.)
 
     ! DIC (Dissolved inorganic carbon)
@@ -1682,7 +1679,6 @@ module generic_WOMBATlite
         units = 'mol/kg', &
         prog = .true., &
         flux_gas = .true., &
-        flux_bottom = .false., &
         flux_gas_name = 'co2_pre_flux', &
         flux_gas_type = 'air_sea_gas_flux_generic', &
         flux_gas_molwt = WTMCO2, &
@@ -1697,8 +1693,7 @@ module generic_WOMBATlite
         longname = 'remineralised Dissolved Inorganic Carbon', &
         units = 'mol/kg', &
         prog = .true., &
-        flux_bottom = .true., &
-        flux_virtual = .true.)
+        flux_bottom = .true.)
 
     ! Alk (Total carbonate alkalinity)
     !-----------------------------------------------------------------------
@@ -2033,7 +2028,6 @@ module generic_WOMBATlite
     real                                    :: phy_pisl, phy_pisl2 
     real                                    :: pchl_pisl, pchl_mumin, pchl_muopt
     real, dimension(:,:), allocatable       :: ek_bgr, par_bgr_mid, par_bgr_top
-    !real, dimension(:,:), allocatable       :: seddep, sedmask
     real, dimension(:), allocatable         :: wsink, wsinkcal
     real, dimension(4,61)                   :: zbgr
     real                                    :: max_wsink
@@ -2148,9 +2142,6 @@ module generic_WOMBATlite
     ! and pco2surf, so it makes sense to set these values here rather than
     ! recalculating them in set_boundary_values.
     
-    !allocate(sedmask(isc:iec,jsc:jec)); sedmask(:,:)=0.0
-    !allocate(seddep(isc:iec,jsc:jec)); seddep(:,:)=0.0
-
     call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau, &
         positive=.true.)
     call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau, &
@@ -2541,7 +2532,7 @@ module generic_WOMBATlite
       wombat%phy_kni(i,j,k) = wombat%phykn * max(0.1, max(0.0, (biophy-wombat%phybiot))**0.37)
       wombat%phy_kfe(i,j,k) = wombat%phykf * max(0.1, max(0.0, (biophy-wombat%phybiot))**0.37)
       ! Nitrogen limitation (currently Michaelis-Menten term)
-      wombat%phy_lnit(i,j,k) = biono3 / (biono3 + wombat%phy_kni(i,j,k))
+      wombat%phy_lnit(i,j,k) = biono3 / (biono3 + wombat%phy_kni(i,j,k) + epsi)
       ! Iron limitation (Quota model, constants from Flynn & Hipkin 1999)
       phy_minqfe = 0.00167 / 55.85 * max(wombat%phyminqc, phy_chlc)*12 + &
                    1.21e-5 * 14.0 / 55.85 / 7.625 * 0.5 * 1.5 * wombat%phy_lnit(i,j,k) + &
@@ -2803,7 +2794,6 @@ module generic_WOMBATlite
       
       if (wombat%f_det(i,j,k) .gt. epsi) then
         wombat%detremi(i,j,k) = wombat%reminr(i,j,k) / mmol_m3_to_mol_kg * wombat%f_det(i,j,k)**2.0 ! [molC/kg/s]
-        !if (wombat%zw(i,j,k) .ge. 180.0) wombat%detremi(i,j,k) = wombat%detremi(i,j,k) * 0.5
       else
         wombat%detremi(i,j,k) = 0.0
       endif

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -156,6 +156,9 @@ module generic_WOMBATlite
         caco3lrem, &
         caco3lrem_sed, &
         f_inorg, &
+        disscal, &
+        dissara, &
+        dissdet, &
         ligand, &
         knano_dfe, &
         kscav_dfe, &
@@ -1430,6 +1433,18 @@ module generic_WOMBATlite
     ! CaCO3 inorganic fraction [1]
     !-----------------------------------------------------------------------
     call g_tracer_add_param('f_inorg', wombat%f_inorg, 0.04)
+
+    ! CaCO3 dissolution factor due to calcite undersaturation
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('disscal', wombat%disscal, 0.500)
+
+    ! CaCO3 dissolution factor due to aragonite undersaturation 
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('dissara', wombat%dissara, 0.100)
+
+    ! CaCO3 dissolution factor due to detritus remineralisation creating anoxic microenvironment
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('dissdet', wombat%dissdet, 0.250)
 
     ! Background concentration of iron-binding ligand [umol/m3]
     !-----------------------------------------------------------------------
@@ -2709,9 +2724,9 @@ module generic_WOMBATlite
 
         ! The dissolution rate is a function of omegas for calcite and aragonite, as well the
         !  concentration of POC, following Kwon et al., 2024, Science Advances; Table S1
-        diss_cal = (0.253 * max(0.0, 1.0 - wombat%omega_cal(i,j,k))**2.2) / 86400.0
-        diss_ara = (0.090 * max(0.0, 1.0 - wombat%omega_ara(i,j,k))**1.5) / 86400.0
-        diss_det = (0.250 * wombat%reminr(i,j,k) * biodet**2.0)
+        diss_cal = (wombat%disscal * max(0.0, 1.0 - wombat%omega_cal(i,j,k))**2.2) / 86400.0
+        diss_ara = (wombat%dissara * max(0.0, 1.0 - wombat%omega_ara(i,j,k))**1.5) / 86400.0
+        diss_det = (wombat%dissdet * wombat%reminr(i,j,k) * biodet**2.0)
         wombat%dissrat(i,j,k) = diss_cal + diss_ara + diss_det
 
       else


### PR DESCRIPTION
To include variable sinking rates in WOMBAT-lite within the generic tracers framework I have had to slightly extend the tri-diagonal (implicit) solver for vertical diffusion within the _generic_tracer_utils.F90_ file. Specifically, I have altered the "IOWtridiag" algorithm in the _g_tracer_vertdiff_M_ subroutine. This algorithm previously solved only for the vertical movement of tracer within the water column, but did not account for the passing of tracer from the ocean model into a bottom reservoir. I have simply extended this algorithm to include the passing of some tracer into a bottom reservoir (i.e., sediment pool).

I have also made additions in the form of:

* Zooplankton grazing on organic detritus
* More diagnostics of zooplankton grazing, sloppy feeding and excretion associated with both phytoplankton and detritus prey, as well as a remineralisation rate diagnostic
* Slight alterations to the parameters (not final)
* Updates to nutrient limitation calculations, including the fixing of a bug in the iron limitation term
* More diagnostics related to iron cycling
* Movement of DIC and aDIC tracers into the sources and sinks nested timestep as part of the ecosystem cycling
* Removal of virtual fluxes which was causing unrealistic accumulation of NO3, DIC, Alk in the surface ocean.