### PR TITLE
Changes to allow using gtracers in another CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(libgtracers
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
+include(CheckFortranCompilerFlag)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Relwithdebinfo' as none was specified.")
@@ -35,6 +36,14 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
 
   # Copied from MOM5/bin/mkmf.template.nci.gfortran
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcray-pointer -fdefault-real-8 -ffree-line-length-none -fno-range-check -Waliasing -Wampersand -Warray-bounds -Wcharacter-truncation -Wconversion -Wline-truncation -Wintrinsics-std -Wsurprising -Wno-tabs -Wunderflow -Wunused-parameter -Wintrinsic-shadow -Wno-align-commons")
+  check_fortran_compiler_flag("-fallow-invalid-boz" _boz_flag)
+  check_fortran_compiler_flag("-fallow-argument-mismatch" _argmis_flag)
+  if(_boz_flag)
+    set(CMAKE_Fortran_FLAGS               "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz" )
+  endif()
+  if(_argmis_flag)
+    set(CMAKE_Fortran_FLAGS               "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch" )
+  endif()
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
   set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g")
   set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -W -fbounds-check")
@@ -42,7 +51,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
 
   # Copied from MOM5/bin/mkmf.template.nci
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
   set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
@@ -50,7 +59,7 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
 elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
 
   # Copied from MOM5/bin/mkmf.template.nci
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -align all")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-alias -safe-cray-ptr -fpe0 -ftz -assume byterecl -i4 -r8 -traceback -nowarn -check noarg_temp_created -assume nobuffered_io -convert big_endian -grecord-gcc-switches -fp-model precise -fp-model source -align all")
   set(CMAKE_Fortran_FLAGS_RELEASE "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(libgtracers
 )
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
   message(STATUS "Setting build type to 'Relwithdebinfo' as none was specified.")
@@ -102,6 +103,16 @@ install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ TYPE INCLUDE)
 install(EXPORT GFDLGTracersTargets
   FILE GFDLGTracersTargets.cmake
   NAMESPACE GFDLGTracers::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GFDLGTracers
+)
+
+configure_package_config_file(
+  cmake/GFDLGTracersConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/GFDLGTracersConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GFDLGTracers
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/GFDLGTracersConfig.cmake
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/GFDLGTracers
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ target_link_libraries(gtracers PUBLIC
 install(TARGETS gtracers
         EXPORT GFDLGTracersTargets)
 
+target_include_directories(gtracers PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
+
 install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/ TYPE INCLUDE)
 
 install(EXPORT GFDLGTracersTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,8 @@ endif()
 ################################################################################
 
 find_package(MPI REQUIRED COMPONENTS Fortran)
+find_package(fms COMPONENTS R8 REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
-pkg_check_modules(FMS REQUIRED IMPORTED_TARGET "FMS")
 pkg_check_modules(MOCSY REQUIRED IMPORTED_TARGET "mocsy")
 
 add_library(gtracers STATIC)
@@ -89,9 +88,8 @@ target_sources(gtracers PRIVATE
 )
 
 target_link_libraries(gtracers PUBLIC
-			PkgConfig::FMS
-			PkgConfig::MOCSY
-			PkgConfig::NETCDF)
+			FMS::fms_r8
+			PkgConfig::MOCSY)
 
 install(TARGETS gtracers
         EXPORT GFDLGTracersTargets)

--- a/cmake/GFDLGTracersConfig.cmake.in
+++ b/cmake/GFDLGTracersConfig.cmake.in
@@ -12,9 +12,8 @@ include(CMakeFindDependencyMacro)
 set(_required_components ${GFDLGTracers_FIND_COMPONENTS})
 
 find_package(MPI REQUIRED COMPONENTS Fortran)
+find_package(fms COMPONENTS R8 REQUIRED)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
-pkg_check_modules(FMS REQUIRED IMPORTED_TARGET "FMS")
 pkg_check_modules(MOCSY REQUIRED IMPORTED_TARGET "mocsy")
 
 # Run the normal Targets.cmake

--- a/cmake/GFDLGTracersConfig.cmake.in
+++ b/cmake/GFDLGTracersConfig.cmake.in
@@ -1,0 +1,26 @@
+# Copyright ACCESS-NRI and contributors. See the top-level LICENSE file for details.
+
+@PACKAGE_INIT@
+
+if(NOT GFDLGTracers_FIND_QUIETLY)
+  message(STATUS "Found GFDLGTracers: ${PACKAGE_PREFIX_DIR}")
+endif()
+
+include(CMakeFindDependencyMacro)
+
+# Request components
+set(_required_components ${GFDLGTracers_FIND_COMPONENTS})
+
+find_package(MPI REQUIRED COMPONENTS Fortran)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET "netcdf-fortran")
+pkg_check_modules(FMS REQUIRED IMPORTED_TARGET "FMS")
+pkg_check_modules(MOCSY REQUIRED IMPORTED_TARGET "mocsy")
+
+# Run the normal Targets.cmake
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+include("${CMAKE_CURRENT_LIST_DIR}/GFDLGTracersTargets.cmake")
+list(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# Check the requested components are valid
+check_required_components(_required_components)


### PR DESCRIPTION
This PR includes changes to the generic_tracer CMake build system needed to use gtracers in the MOM5 CMake build system I am working on.

The changes are:
1. Adding `CMAKE_INSTALL_INCLUDEDIR` to gtracers include directories
2. Configuring and installing a CMake package config file. This allows `find_package(GFDLGTracers ...)` from other CMake projects.
3. Using `find_package` for the FMS dependency. Using PkgConfig for FMS leads to the following error for me when trying to link gtracers in the MOM5 Cmake:
    ```
    /bin/ld: cannot find -lFMS
    ```
    Moving to `find_package` fixes the issue, but does mean that we need to add `FindNetCDF.cmake` to the gtracer build system to allow building with FMS < 2025.02. For FMS >= 2025.02, this is not needed as FMS now exports `FindNetCDF.cmake` (thanks to @micaeljtoliveira).


@harshula, I expect you won't be happy with point 3. I'm happy to remove that commit, but I'll need your help getting the PkgConfig approach working.