### PR TITLE
Add Build CI

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,0 +1,5 @@
+{
+  "intel_compiler": "intel@2021.10.0",
+  "gcc_compiler": "gcc@13.2.0",
+  "oneapi_compiler": "oneapi@2025.2.0"
+}

--- a/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
@@ -3,6 +3,9 @@ spack:
   # *_compiler is defined in the .github/build-ci/data/standard.json file
   - access-generic-tracers@git.{{ ref }} ~use_access_fms
   packages:
+    fms:
+      require:
+        - '@git.2025.02=2025.02'
     all:
       require:
       - '%{{ gcc_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  # *_compiler is defined in the .github/build-ci/data/standard.json file
+  - access-generic-tracers@git.{{ ref }} ~use_access_fms
+  packages:
+    all:
+      require:
+      - '%{{ gcc_compiler }} target=x86_64'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     fms:
       require:
-        - '@git.2025.02=2025.02 ~openmp'
+        - '@git.2025.02=2025.02 ~openmp precision=64'
     all:
       require:
       - '%{{ gcc_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-no-use_access_fms.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     fms:
       require:
-        - '@git.2025.02=2025.02'
+        - '@git.2025.02=2025.02 ~openmp'
     all:
       require:
       - '%{{ gcc_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/gcc-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-use_access_fms.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  # *_compiler is defined in the .github/build-ci/data/standard.json file
+  - access-generic-tracers@git.{{ ref }} +use_access_fms
+  packages:
+    all:
+      require:
+      - '%{{ gcc_compiler }} target=x86_64'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     fms:
       require:
-        - '@git.2025.02=2025.02 ~openmp'
+        - '@git.2025.02=2025.02 ~openmp precision=64'
     all:
       require:
       - '%{{ intel_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  # *_compiler is defined in the .github/build-ci/data/standard.json file
+  - access-generic-tracers@git.{{ ref }} ~use_access_fms
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }} target=x86_64'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     fms:
       require:
-        - '@git.2025.02=2025.02'
+        - '@git.2025.02=2025.02 ~openmp'
     all:
       require:
       - '%{{ intel_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-no-use_access_fms.spack.yaml.j2
@@ -3,6 +3,9 @@ spack:
   # *_compiler is defined in the .github/build-ci/data/standard.json file
   - access-generic-tracers@git.{{ ref }} ~use_access_fms
   packages:
+    fms:
+      require:
+        - '@git.2025.02=2025.02'
     all:
       require:
       - '%{{ intel_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/intel-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-use_access_fms.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  # *_compiler is defined in the .github/build-ci/data/standard.json file
+  - access-generic-tracers@git.{{ ref }} +use_access_fms
+  packages:
+    all:
+      require:
+      - '%{{ intel_compiler }} target=x86_64'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  # *_compiler is defined in the .github/build-ci/data/standard.json file
+  - access-generic-tracers@git.{{ ref }} ~use_access_fms
+  packages:
+    all:
+      require:
+      - '%{{ oneapi_compiler }} target=x86_64'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
@@ -3,6 +3,9 @@ spack:
   # *_compiler is defined in the .github/build-ci/data/standard.json file
   - access-generic-tracers@git.{{ ref }} ~use_access_fms
   packages:
+    fms:
+      require:
+        - '@git.2025.02=2025.02'
     all:
       require:
       - '%{{ oneapi_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
@@ -6,6 +6,9 @@ spack:
     fms:
       require:
         - '@git.2025.02=2025.02'
+    gcc-runtime:
+      require:
+        - '%gcc'
     all:
       require:
       - '%{{ oneapi_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     fms:
       require:
-        - '@git.2025.02=2025.02 ~openmp'
+        - '@git.2025.02=2025.02 ~openmp precision=64'
     gcc-runtime:
       require:
         - '%gcc'

--- a/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-no-use_access_fms.spack.yaml.j2
@@ -5,7 +5,7 @@ spack:
   packages:
     fms:
       require:
-        - '@git.2025.02=2025.02'
+        - '@git.2025.02=2025.02 ~openmp'
     gcc-runtime:
       require:
         - '%gcc'

--- a/.github/build-ci/manifests/oneapi-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-use_access_fms.spack.yaml.j2
@@ -3,6 +3,9 @@ spack:
   # *_compiler is defined in the .github/build-ci/data/standard.json file
   - access-generic-tracers@git.{{ ref }} +use_access_fms
   packages:
+    gcc-runtime:
+      require:
+        - '%gcc'
     all:
       require:
       - '%{{ oneapi_compiler }} target=x86_64'

--- a/.github/build-ci/manifests/oneapi-use_access_fms.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-use_access_fms.spack.yaml.j2
@@ -1,0 +1,11 @@
+spack:
+  specs:
+  # *_compiler is defined in the .github/build-ci/data/standard.json file
+  - access-generic-tracers@git.{{ ref }} +use_access_fms
+  packages:
+    all:
+      require:
+      - '%{{ oneapi_compiler }} target=x86_64'
+  concretizer:
+    unify: false
+  view: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     uses: access-nri/build-ci/.github/workflows/ci.yml@v2
     with:
       spack-manifest-path: ${{ matrix.file }}
+      spack-manifest-data-path: .github/build-ci/data/standard.json
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       # spack-packages-ref: main
       # spack-config-ref: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Build
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+jobs:
+  pre-ci:
+    name: Pre-CI
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up matrix
+        id: set-matrix
+        # Find all relevant files under .github/build-ci/manifests
+        # then output them as a JSON array (minus the last comma)
+        run: |
+          files=$(find .github/build-ci/manifests/ -iname '*.j2' -printf '"%p",')
+          echo "matrix=[${files%,}]" >> $GITHUB_OUTPUT
+
+  ci:
+    name: CI
+    needs: pre-ci
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    with:
+      spack-manifest-path: ${{ matrix.file }}
+      allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
+      # spack-packages-ref: main
+      # spack-config-ref: main
+      # spack-ref: releases/v0.22


### PR DESCRIPTION
Closes #43

Pinging @dougiesquire

## Background

Adding Build CI to GFDL-generic-tracers. We are testing `gcc`, `intel`, `oneapi`, all with `use_access_fms` on or off. 

## The PR

- **Add matrix-enabled CI workflow**
- **Add manifests for gcc, intel, oneapi and [+~]use_access_fms, add standard datafile**
