### PR TITLE
Major update to WOMBATlite: #83

### DIFF
--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1416,6 +1416,8 @@ module generic_WOMBATlite
         longname = 'Nitrate', &
         units = 'mol/kg', &
         prog = .true., &
+        flux_runoff = .true., &
+        flux_param  = (/ 1.0 /), & ! dts: trunoff supplied in mol/kg
         flux_bottom = .true., &
         flux_virtual = .true.)
 
@@ -1484,6 +1486,8 @@ module generic_WOMBATlite
         longname = 'Detritus', &
         units = 'mol/kg', &
         prog = .true., &
+        flux_runoff = .true., &
+        flux_param  = (/ 1.0 /), & ! dts: trunoff supplied in mol/kg
         move_vertical = .true., &
         btm_reservoir = .true.)
 
@@ -1515,12 +1519,14 @@ module generic_WOMBATlite
         units = 'mol/kg', &
         prog = .true., &
         flux_gas = .true., &
-        flux_bottom = .true., &
         flux_gas_name = 'co2_flux', &
         flux_gas_type = 'air_sea_gas_flux_generic', &
         flux_gas_molwt = WTMCO2, &
         flux_gas_param = (/ as_coeff_wombatlite, 9.7561e-06 /), & ! dts: param(2) converts Pa -> atm
         flux_gas_restart_file = 'ocean_wombatlite_airsea_flux.res.nc', &
+        flux_runoff = .true., &
+        flux_param  = (/ 1.0 /), & ! dts: trunoff supplied in mol/kg
+        flux_bottom = .true., &
         flux_virtual = .true.)
 
     ! DICp (preformed Dissolved inorganic carbon)
@@ -1550,6 +1556,8 @@ module generic_WOMBATlite
         longname = 'Alkalinity', &
         units = 'mol/kg', &
         prog = .true., &
+        flux_runoff = .true., &
+        flux_param  = (/ 1.0 /), & ! dts: trunoff supplied in mol/kg
         flux_bottom = .true., &
         flux_virtual = .true.)
 
@@ -1561,7 +1569,7 @@ module generic_WOMBATlite
         units = 'mol/kg', &
         prog = .true., &
         flux_drydep = .true., &
-        flux_param  = (/ 1.0 /), & ! dts: conversion to mol/m2/s done in data_table
+        flux_param  = (/ 1.0 /), & ! dts: fe flux supplied in mol/m2/s
         flux_bottom = .true.)
 
     !=======================================================================


### PR DESCRIPTION
#83 

* light attenuation now includes effects from detritus and CaCO3
* aesthetic changes to code and sections
* CaCO3 cycle now has outputs diagnostics for Cal, Ara and POC-associated dissolution
* removed many unnecessary diagnostics
* removed the "do_conserve_tracers" input option since now we have explicit runoff additions of tracers that can balance burial
* complete rewrite of the chlorophyll growth routine to align with Geider, MacIntrye & Kana (1997) formulation
* removed the "alk_correct" and "dic_correct" additions of Alk and DIC because we now have runoff additions of these tracers