### PR TITLE
WOMBATlite: Allow negative tracers

### DIFF
--- a/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
+++ b/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
@@ -22,21 +22,21 @@ The following are the active tracers in WOMBAT-lite
 
 | Tracer           | Code name  | Description                                 | Units                     | Default on? |
 |------------------|------------|---------------------------------------------|---------------------------|-------------|
-| O<sub>2</sub>    | `f_o2`     | Dissolved oxygen                            | mol O2 kg<sup>-1</sup>    | Yes         |
-| NO<sub>3</sub>   | `f_no3`    | Nitrate                                     | mol N kg<sup>-1</sup>     | Yes         |
-| dFe              | `f_fe`     | Dissolved iron                              | mol Fe kg<sup>-1</sup>    | Yes         |
-| Phy              | `f_phy`    | Phytoplankton                               | mol C kg<sup>-1</sup>     | Yes         |
-| Zoo              | `f_zoo`    | Zooplankton                                 | mol C kg<sup>-1</sup>     | Yes         |
-| Det              | `f_det`    | Detritus                                    | mol C kg<sup>-1</sup>     | Yes         |
-| Chl              | `f_pchl`   | Phytoplankton chlorophyll content           | mol C kg<sup>-1</sup>     | Yes         |
-| PhyFe            | `f_phyfe`  | Phytoplankton iron content                  | mol Fe kg<sup>-1</sup>    | Yes         |
-| ZooFe            | `f_zoofe`  | Zoooplankton iron content                   | mol Fe kg<sup>-1</sup>    | Yes         |
-| DetFe            | `f_detfe`  | Detritus iron content                       | mol Fe kg<sup>-1</sup>    | Yes         |
-| DIC              | `f_dic`    | Dissolved inorganic carbon                  | mol C kg<sup>-1</sup>     | Yes         |
-| Alk              | `f_alk`    | Dissolved alkalinity                        | mol Eq kg<sup>-1</sup>    | Yes         |
-| CaCO<sub>3</sub> | `f_caco3`  | Calcium carbonate                           | mol C kg<sup>-1</sup>     | Yes         |
-| DICp             | `f_dicp`   | Preformed dissolved inorganic carbon        | mol C kg<sup>-1</sup>     | No          |
-| DICr             | `f_dicr`   | Remineralised dissolved inorganic carbon    | mol C kg<sup>-1</sup>     | No          |
+| O<sub>2</sub>    | `p_o2`     | Dissolved oxygen                            | mol O2 kg<sup>-1</sup>    | Yes         |
+| NO<sub>3</sub>   | `p_no3`    | Nitrate                                     | mol N kg<sup>-1</sup>     | Yes         |
+| dFe              | `p_fe`     | Dissolved iron                              | mol Fe kg<sup>-1</sup>    | Yes         |
+| Phy              | `p_phy`    | Phytoplankton                               | mol C kg<sup>-1</sup>     | Yes         |
+| Zoo              | `p_zoo`    | Zooplankton                                 | mol C kg<sup>-1</sup>     | Yes         |
+| Det              | `p_det`    | Detritus                                    | mol C kg<sup>-1</sup>     | Yes         |
+| Chl              | `p_pchl`   | Phytoplankton chlorophyll content           | mol C kg<sup>-1</sup>     | Yes         |
+| PhyFe            | `p_phyfe`  | Phytoplankton iron content                  | mol Fe kg<sup>-1</sup>    | Yes         |
+| ZooFe            | `p_zoofe`  | Zoooplankton iron content                   | mol Fe kg<sup>-1</sup>    | Yes         |
+| DetFe            | `p_detfe`  | Detritus iron content                       | mol Fe kg<sup>-1</sup>    | Yes         |
+| DIC              | `p_dic`    | Dissolved inorganic carbon                  | mol C kg<sup>-1</sup>     | Yes         |
+| Alk              | `p_alk`    | Dissolved alkalinity                        | mol Eq kg<sup>-1</sup>    | Yes         |
+| CaCO<sub>3</sub> | `p_caco3`  | Calcium carbonate                           | mol C kg<sup>-1</sup>     | Yes         |
+| DICp             | -          | Preformed dissolved inorganic carbon        | mol C kg<sup>-1</sup>     | No          |
+| DICr             | `p_dicr`   | Remineralised dissolved inorganic carbon    | mol C kg<sup>-1</sup>     | No          |
 
 ---
 
@@ -50,6 +50,8 @@ The following are logical statements within the `input.nml` namelist file that c
 | `do_colloidal_shunt`  | Fraction of dissolved iron is colloids that coagulate onto sinking material | .true.           |
 | `do_two_ligands`      | Complex soluble iron using two ligands (weak + strong) rather than one      | .false.          |
 | `do_burial`           | Permanently bury a fraction of sinking detrital material into the sediments | .false.          |
+| `do_tracer_dicp`      | Carry preformed dissolved inorganic carbon (dicp) as a tracer               | .false.          |
+| `do_tracer_dicr`      | Carry remineralised dissolved inorganic carbon (dicr) as a tracer           | .false.          |
 | `do_check_n_conserve` | Checks that the ecosystem calculations are conserving the mass of nitrogen  | .false.          |
 | `do_check_c_conserve` | Checks that the ecosystem calculations are conserving the mass of carbon    | .false.          |
 
@@ -321,7 +323,7 @@ The euphotic depth (`zeuphot(i,j)`, [m]) is defined as the depth where `radbio` 
 
 ### 2. Nutrient limitation of phytoplankton.
 
-At the start of each vertical loop the code computes biomass of phytoplankton (`biophy`, $B_{phy}^{C}$, [mmol C m<sup>-3</sup>]). Phytoplankton biomass is used to scale how both nitrate (`biono3`, $NO_{3}$, [mmol NO<sub>3</sub> m<sup>-3</sup>]) and dissolved iron (`biofer`, $dFe$, [µmol Fe m<sup>-3</sup>]) affect the growth of phytoplankton. Using compilations of marine phytoplankton and zooplankton communities, [Wickman et al. (2024)](https://www.science.org/doi/10.1126/science.adk6901) show that the nutrient affinity, $\mathit{aff}$, of a phytoplankton cell is related to its volume, $V$, via
+At the start of each vertical loop the code computes biomass of phytoplankton (`phy_mmolm3`, $B_{phy}^{C}$, [mmol C m<sup>-3</sup>]). Phytoplankton biomass is used to scale how both nitrate (`no3_mmolm3`, $NO_{3}$, [mmol NO<sub>3</sub> m<sup>-3</sup>]) and dissolved iron (`fe_umolm3`, $dFe$, [µmol Fe m<sup>-3</sup>]) affect the growth of phytoplankton. Using compilations of marine phytoplankton and zooplankton communities, [Wickman et al. (2024)](https://www.science.org/doi/10.1126/science.adk6901) show that the nutrient affinity, $\mathit{aff}$, of a phytoplankton cell is related to its volume, $V$, via
 
 $$
 \begin{align}
@@ -363,7 +365,7 @@ L_{phy}^{N} =& \quad \dfrac{NO_3}{NO_3 + K_{phy}^{N}}
 $$
  
 _where _ <br>
-- $NO_3$ is the ambient nitrate concentration (`biono3`, $NO_3$, [mmol N m<sup>-3</sup>]) <br>
+- $NO_3$ is the ambient nitrate concentration (`no3_mmolm3`, $NO_3$, [mmol N m<sup>-3</sup>]) <br>
 - $K_{phy}^{N}$ is the michaelis-menten half-saturation coefficient (`phy_kni(i,j,k)`, [mmol N m<sup>-3</sup>]) <br>
 
 **Limitation of phytoplankton growth by iron** follows an internal quota approach ([Droop, 1983](https://www.degruyterbrill.com/document/doi/10.1515/botm.1983.26.3.99/html)). Phytoplankton have a minimum iron quota (`phy_minqfe`, $Q_{phy}^{-Fe:C}$, [mol Fe (mol C)<sup>-1</sup>]) and an optimal quota for growth (`phyoptqf`, $Q_{phy}^{*Fe:C}$, [mol Fe (mol C)<sup>-1</sup>]). The minimum iron quota, $Q_{phy}^{-Fe:C}$, is dependent on the chlorophyll content of the cell and the degree of nitrogen limitation according to
@@ -492,7 +494,7 @@ $$
 
 _where_ <br>
 - $\mu_{phy}^{\leftarrow C}$ is the realized rate of carbon biomass growth by phytoplankton (`phygrow(i,j,k)`, [mol C kg<sup>-1</sup> s<sup>-1</sup>]) <br>
-- $B_{phy}^{C}$ is the carbon concentration of phytoplankton (`biophy`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C}$ is the carbon concentration of phytoplankton (`phy_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 ---
 
@@ -537,10 +539,10 @@ $$
 
 _where_ <br>
 - $Q_{phy}^{Chl:C}$ is the in-situ chlorophyll-to-carbon ratio (`phy_chlc`, [mol C (mol C)<sup>-1</sup>]) <br>
-- $B_{phy}^{Chl}$ is the in-situ concentation of phytoplankton chlorophyll (`f_pchl(i,j,k)`, [mol C kg<sup>-1</sup>]) <br>
+- $B_{phy}^{Chl}$ is the in-situ concentation of phytoplankton chlorophyll (`p_pchl(i,j,k,tau)`, [mol C kg<sup>-1</sup>]) <br>
 - $\mu_{phy}$ is the realized growth rate of phytoplankton (`phy_mu(i,j,k)`, [s<sup>-1</sup>]) <br>
 - $\tau^{Chl}$ is the timescale over which chlorophyll synthesis occurs within the cell (`chltau`, [s]) <br>
-- $B_{phy}^{C}$ is the in-situ concentation of phytoplankton carbon (`f_phy(i,j,k)`, [mol C kg<sup>-1</sup>]) <br>
+- $B_{phy}^{C}$ is the in-situ concentation of phytoplankton carbon (`p_phy(i,j,k,tau)`, [mol C kg<sup>-1</sup>]) <br>
 
 This formulation elevates chlorophyll-to-carbon ratios in low light and supresses synthesis when nutrients are low. $\tau_{phy}^{Chl}$ is an input parameter at run time and should ideally be less than the doubling time of phytplankton given that phytoplankton can internally regulate their chlorophyll stores at rates greater than their overall growth.
 
@@ -560,7 +562,7 @@ $$
 _where_ <br>
 - $B_{phy}^{+Fe}$ is the maximum Fe quota of the cell (`phy_maxqfe`, [mmol Fe m<sup>-3</sup>]) <br>
 - $Q_{phy}^{+Fe:C}$ is the maximum Fe:C ratio of the cell (`phymaxqf`, [mol Fe (mol C)<sup>-1</sup>]) <br>
-- $B_{phy}^{C}$ is the in-situ concentation of phytoplankton carbon (`f_phy(i,j,k)`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C}$ is the in-situ concentation of phytoplankton carbon (`p_phy(i,j,k,tau)`, [mmol C m<sup>-3</sup>]) <br>
 
 Following [Aumont et al. (2015)](https://gmd.copernicus.org/articles/8/2465/2015/), this rate is scaled by three terms relating to (i) the michaelis-menten type affinity for dFe, (ii) up-regulation of dFe uptake representing investment in transporters when cell quotas are limiting to growth, and (iii) down regulation of dFe uptake associated with enriched cellular quotas:
 
@@ -573,10 +575,10 @@ $$
 $$
 
 _where_ <br>
-- $dFe$ is the in situ dissolved iron concentation (`biofer`, [µmol Fe m<sup>-3</sup>]) <br>
+- $dFe$ is the in situ dissolved iron concentation (`fe_umolm3`, [µmol Fe m<sup>-3</sup>]) <br>
 - $K_{phy}^{Fe}$ is the half-saturation coefficient for dFe uptake by phytoplankton (`phy_kfe(i,j,k)`, [µmol Fe m<sup>-3</sup>]) <br>
 - $L_{phy}^{Fe}$ is the growth limiter by iron (`phy_lfer(i,j,k)`, [dimensionless]) <br>
-- $B_{phy}^{Fe}$ is the in situ Fe quota of the cell (`biophyfe`, [mmol Fe m<sup>-3</sup>]) <br>
+- $B_{phy}^{Fe}$ is the in situ Fe quota of the cell (`phyfe_mmolm3`, [mmol Fe m<sup>-3</sup>]) <br>
 - $B_{phy}^{+Fe}$ is the maximum Fe quota of the cell (`phy_maxqfe`, [mmol Fe m<sup>-3</sup>]) <br>
 
 Note that we additionally include a fourth term that decreases the maximum dFe uptake of a cell under light limitation. This is informed by slower uptake of Fe by cells grown in darkness compared to those grown in light by roughly 10-fold ([Strzepek et al., 2025](https://doi.org/10.1093/ismejo/wraf015)), which may be due to physiological stimulation of Fe uptake machinery or photoreduction of ligand-bound iron complexes ([Kong et al., 2023](https://doi.org/10.1002/lno.12331); [Maldonado et al., 2005](https://doi.org/10.1029/2005GB002481)), or possibly a combination of both. To obtain a 10-fold relative increase in Fe uptake rates under light, we applied the following term:
@@ -608,7 +610,7 @@ _where_ <br>
 
 ### 8. Iron chemistry.
 
-Treatment of dissolved iron (`biofer`, $dFe$, [nmol Fe kg<sup>-1</sup>]) follows a combination of [Aumont et al. (2015)](https://gmd.copernicus.org/articles/8/2465/2015/) and [Tagliabue et al. (2023)](https://www.nature.com/articles/s41586-023-06210-5). Our calculations involve: <br>
+Treatment of dissolved iron (`fe_umolm3`, $dFe$, [nmol Fe kg<sup>-1</sup>]) follows a combination of [Aumont et al. (2015)](https://gmd.copernicus.org/articles/8/2465/2015/) and [Tagliabue et al. (2023)](https://www.nature.com/articles/s41586-023-06210-5). Our calculations involve: <br>
 1. Solving for the distinct pools of dissolved iron: free iron, ligand-bound iron and colloidal iron. <br>
 2. Computing precipitation of free iron into nanoparticles that are permanently lost. <br>
 3. Computing scavenging of free iron onto sinking organic particles. <br>
@@ -653,7 +655,7 @@ _where_ <br>
 - $\times10^{9}$ converts [mol Fe kg<sup>-1</sup>] to [nmol Fe kg<sup>-1</sup>] <br>
 - $dFe_{sol}$ is the final estimated solubility of dissolve iron in seawater (`fe3sol`, [nmol Fe kg<sup>-1</sup>]). <br>
 
-Next we **estimate the concentration of colloidal iron** in solution following [Tagliabue et al. 2023](https://www.nature.com/articles/s41586-023-06210-5) in the case that `do_colloidal_shunt == .true.`. If `do_colloidal_shunt == .false.` we consider no dissolved Fe to be in colloidal form. Colloidal dissolved Fe (`fecol(i,j,k)`, $dFe_{col}$, [mmol Fe m<sup>-3</sup>]) is whatever exceeds the inorganic solubility ceiling (`fe3sol`, $dFe_{sol}$, [mmol Fe m<sup>-3</sup>]), but we enforce a hard minimum that colloids are at least 10% of total dissolved Fe (`biofer`, $dFe$, [mmol Fe m<sup>-3</sup>]).
+Next we **estimate the concentration of colloidal iron** in solution following [Tagliabue et al. 2023](https://www.nature.com/articles/s41586-023-06210-5) in the case that `do_colloidal_shunt == .true.`. If `do_colloidal_shunt == .false.` we consider no dissolved Fe to be in colloidal form. Colloidal dissolved Fe (`fecol(i,j,k)`, $dFe_{col}$, [mmol Fe m<sup>-3</sup>]) is whatever exceeds the inorganic solubility ceiling (`fe3sol`, $dFe_{sol}$, [mmol Fe m<sup>-3</sup>]), but we enforce a hard minimum that colloids are at least 10% of total dissolved Fe (`fe_umolm3`, $dFe$, [mmol Fe m<sup>-3</sup>]).
 
 $$
 \begin{align}
@@ -783,8 +785,8 @@ B_{particles}^{M} =& \quad 2 \cdot B_{det}^{C} + 8.3 \cdot B_{CaCO_3}^{C}
 $$
 
 _where_ <br>
-- $B_{det}^{C}$ is the concentration of particulate organic carbon (`biodet`, [mmol C m<sup>-3</sup>]) <br>
-- $B_{CaCO_3}^{C}$ is the concentration of particulate calcium carbonate in units of carbon (`biocaco3`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{det}^{C}$ is the concentration of particulate organic carbon (`det_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{CaCO_3}^{C}$ is the concentration of particulate calcium carbonate in units of carbon (`caco3_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 Total scavenging ($Sc_{dFe}^{\rightarrow}$) of free iron is broken into the part that attaches to organic detritus (`fescadet(i,j,k)`, $Sc_{dFe}^{\rightarrow B_{det}^{Fe}}$, [nmol Fe kg<sup>-1</sup> s<sup>-1</sup>]):
 
@@ -824,9 +826,9 @@ $$
 _where_ <br>
 - $H_{mix}$ is a Heaviside step function that is equalt to 1 in the mixed layer and 0.01 beneath the mixed layer (`shear`, [dimensionless]) <br>
 - $F_{coag}$ is a phytoplankton concentration dependent coagulation factor (`biof`, [dimensionless])  <br>
-- $B_{phy}^{C}$ is the concentrations of phytoplankton biomass (`biophy`, [mmol C m<sup>-3</sup>])  <br>
+- $B_{phy}^{C}$ is the concentrations of phytoplankton biomass (`phy_mmolm3`, [mmol C m<sup>-3</sup>])  <br>
 - $[DOC]$ is an empirical concentration of DOC and is equal to $40 + 40 \left( 1 - \min\left(L_{phy}^{N} \ , \ L_{phy}^{Fe}\right) \right)$ (`biodoc`, [mmol m<sup>-3</sup>]) <br>
-- $B_{det}^{C}$ is the concentration of organic detrital particles (`biodet`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{det}^{C}$ is the concentration of organic detrital particles (`det_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 - $\gamma_{dFe}^{agg}$ is the colloidal iron aggregation rate constant (`kagg_col`, [s<sup>-1</sup>]) <br>
 - $K_{dFe}^{agg}$ is the half-saturation coefficient for colloidal iron aggregation (`kagg_kcol`, [µmol m<sup>-3</sup>]) <br>
 
@@ -864,8 +866,8 @@ _where_ <br>
 - $\gamma_{zoo}^{0^{\circ}C}$ is the linear loss rate of zooplankton biomass at 0ºC (`zoolmor`, [s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature (`Temp(i,j,k)`, [ºC]) <br>
-- $B_{phy}^{C}$ is the concentration of phytoplankton carbon biomass (`biophy`, [mmol C m<sup>-3</sup>]) <br>
-- $B_{zoo}^{C}$ is the concentration of zooplankton carbon biomass (`biozoo`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C}$ is the concentration of phytoplankton carbon biomass (`phy_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{zoo}^{C}$ is the concentration of zooplankton carbon biomass (`zoo_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 - $K_{zoo}^{\gamma}$ is the half-saturation coefficient for scaling down linear mortality losses (`zookz`, [mmolC m <sup>-3</sup>]) <br>
 
 
@@ -885,8 +887,8 @@ _where_ <br>
 - $\Gamma_{zoo}^{0^{\circ}C}$ is the quadratic (density-dependent) loss rate of zooplankton biomass at 0ºC (`zooqmor`, [(mmol C m<sup>-3</sup>)<sup>-1</sup> s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature (`Temp(i,j,k)`, [ºC]) <br>
-- $B_{phy}^{C}$ is the concentration of phytoplankton carbon biomass (`biophy`, [mmol C m<sup>-3</sup>]) <br>
-- $B_{zoo}^{C}$ is the concentration of zooplankton carbon biomass (`biozoo`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C}$ is the concentration of phytoplankton carbon biomass (`phy_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{zoo}^{C}$ is the concentration of zooplankton carbon biomass (`zoo_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 
 **Remineralisation** of detritus is only affected by a quadratic, density-dependent loss term,
@@ -902,7 +904,7 @@ _where_ <br>
 - $\Gamma_{det}^{0^{\circ}C}$ is the quadratic (density-dependent) loss rate of particulate organic detritus at 0ºC (`detlrem`, [(mmol C m<sup>-3</sup>)<sup>-1</sup> s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature (`Temp(i,j,k)`, [ºC]) <br>
-- $B_{det}^{C}$ is the concentration of particulate organic detritus (`biodet`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{det}^{C}$ is the concentration of particulate organic detritus (`det_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 since hydrolyzation of organic detritus is performed by an heterotrophic bacterial population that is not explicitly resolved in the model and their acitivity is density-dependent.
 
@@ -936,7 +938,7 @@ $$
 
 _where_ <br>
 - $g_{zoo}$ is the total specific rate of grazing of zooplankton (`g_zoo`, [s<sup>-1</sup>]) <br>
-- $B_{zoo}^{C}$ is the in situ concentration of zooplankton carbon biomass (`f_zoo(i,j,k)`, [mol C kg<sup>-1</sup>]) <br>
+- $B_{zoo}^{C}$ is the in situ concentration of zooplankton carbon biomass (`p_zoo(i,j,k,tau)`, [mol C kg<sup>-1</sup>]) <br>
 
 This formulation suppresses grazing at very low prey biomass ($B_{prey}^{C}$) due to reduced encounter and clearance rates, accelerates grazing at intermediate prey biomass as zooplankton effectively learn and switch to available prey, and saturates at high prey biomass due to handling-time limitation ([Gentleman and Neuheimer, 2008](https://doi.org/10.1093/plankt/fbn078); Rohr et al., [2022](https://doi.org/10.1016/j.pocean.2022.102878), [2024](https://doi.org/10.1029/2023GL107732)). This choice increases ecosystem stability and prolongs phytoplankton blooms relative to a Type II formulation.
 
@@ -951,8 +953,8 @@ B_{prey}^{C} =& \quad \phi_{zoo}^{phy} B_{phy}^{C} + \phi_{zoo}^{det} B_{det}^{C
 $$
 
 _where_ <br>
-- $B_{phy}^{C}$ is the concentration of phytoplankton biomass (`biophy`, [mmol C m<sup>-3</sup>]) <br>
-- $B_{det}^{C}$ is the concentration of particulate organic detritus (`biodet`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C}$ is the concentration of phytoplankton biomass (`phy_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{det}^{C}$ is the concentration of particulate organic detritus (`det_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 - $\phi_{zoo}^{phy}$ is the relative preference of zooplankton grazing on phytoplankton (`zooprefphy(i,j,k)`, [dimensionless]) <br>
 - $\phi_{zoo}^{det}$ is the relative preference of zooplankton grazing on particulate detritus (`zooprefdet(i,j,k)`, [dimensionless]) <br>
 
@@ -975,7 +977,7 @@ $$
 
 _where_ <br>
 - $\phi_{zoo}^{phy}$ and $\phi_{zoo}^{det}$ are the relative prey preference of zooplankton for phytoplankton and detritus (`zooprefphy(i,j,k)`; `zooprefdet(i,j,k)`, [dimensionless]) <br>
-- $B_{phy}^{C}$ and $B_{det}^{C}$ are the concentrations of phytoplankton and detritus in carbon biomass (`biophy`; `biodet`, [mmol C m<sup>-3</sup>])<br>
+- $B_{phy}^{C}$ and $B_{det}^{C}$ are the concentrations of phytoplankton and detritus in carbon biomass (`phy_mmolm3`; `det_mmolm3`, [mmol C m<sup>-3</sup>])<br>
 - $s_{zoo}$ is the prey-switching exponent of zooplankton (`zoopreyswitch`) <br>
 
 When $s_{zoo} < 1$, zooplankton feed equally across all prey items irrespective of availability  <br>
@@ -1164,7 +1166,7 @@ _where_ <br>
 - $d_{CaCO_3}^{\Omega_{ara}}$ is the reference dissolution rate constant for aragonite (`dissara`, [s<sup>-1</sup>])  <br>
 - $d_{CaCO_3}^{\Gamma_{det}}$ is the reference dissolution rate constant per unit of small detrital organic carbon remineralised (`dissdet`, [(mmol C m<sup>-3</sup>)<sup>-1</sup>])  <br>
 - $\Gamma_{det}^{\rightarrow C}$ is the in situ remineralisation rate of small detrital organic carbon (`detremi(i,j,k)`, [mmol C m<sup>-3</sup> s<sup>-1</sup>]) <br>
-- $B_{CaCO_3}^{C}$ is the in situ concentration of $CaCO_3$ in carbon units (`f_caco3(i,j,k)`, [mol C kg<sup>-1</sup>]) <br>
+- $B_{CaCO_3}^{C}$ is the in situ concentration of $CaCO_3$ in carbon units (`p_caco3(i,j,k,tau)`, [mol C kg<sup>-1</sup>]) <br>
 
 For $D_{CaCO_3}^{\Omega_{cal}}$ and $D_{CaCO_3}^{\Omega_{ara}}$, dissolution is activated only under undersaturated conditions ($\Omega_{cal} < 1$; $\Omega_{ara} < 1$) and increases nonlinearly with increasing undersaturation. In contrast, $D_{CaCO_3}^{\Gamma_{det}^{\rightarrow C}}$ represents shallow water dissolution due to reducing microenvironments. In this scenario, $\Omega_{cal}$ and $\Omega_{ara}$ tend to be > 1 ([Sulpis et al., 2021](https://doi.org/10.1038/s41561-021-00743-y)) but dissolution nonetheless occurs in microenvironments enriched in $CO_{2}^{*}$ due to heterotrophic activity ([Borer et al., 2026](https://doi.org/10.1073/pnas.2510025123)).
 
@@ -1179,7 +1181,7 @@ $$
 _where_ <br>
 - $g_{zoo}^{\leftarrow B_{det}^{C}}$ is the grazing rate of particulate detritus by zooplankton (`zoograzdet(i,j,k)`, [mol C kg<sup>-1</sup> s<sup>-1</sup>]) <br>
 - $F_{gut}$ is the fraction of $CaCO_3$ that is dissolved within zooplankton guts (`fgutdiss`, [mol C (mol C)<sup>-1</sup>]) <br>
-- $\dfrac{B_{CaCO_3}^{C}}{B_{det}^{C}}$ is the in situ ratio of $CaCO_3$ to organic carbon detritus (`biocaco3/biodet`, [mol C (mol C)<sup>-1</sup>]) <br>
+- $\dfrac{B_{CaCO_3}^{C}}{B_{det}^{C}}$ is the in situ ratio of $CaCO_3$ to organic carbon detritus (`caco3_mmolm3/det_mmolm3`, [mol C (mol C)<sup>-1</sup>]) <br>
 
 Here we note that the processing of $CaCO_3$ by zooplankton grazing is treated differently to processing of organic carbon. For organic carbon, we route the biomass between zooplankton biomass (assimilation), inorganic nutrients (excretion) and particulate detritus (egestion). For $CaCO_3$ consumption by zooplankton the $CaCO_3$ is not assimilated since it does not contain nitrogen or other key elements for biosynthesis, and so is only routed between excretion to DIC and alkalinity or goes undissolved and remains $CaCO_3$ that sinks through the water column. This is supported by the fact that micro- and meso-zooplankton may dissolve 92±7% and 38-73% of coccolithophore calcite during feeding, respectively ([Smith et al., 2024](https://www.science.org/doi/10.1126/sciadv.adr5453); [White et al., 2018](https://www.nature.com/articles/s41598-018-28073-x); [Harris 1994](https://link.springer.com/article/10.1007/BF00347540)), and that the remainder is excreted and not assimilated ([Mayers et al., 2020](https://www.frontiersin.org/journals/marine-science/articles/10.3389/fmars.2020.569896/full)).
 
@@ -1193,7 +1195,7 @@ When $CaCO_3$ dynamics are disabled (`do_caco3_dynamics = .false.`), the model u
 
 ### 12. Tracer tendencies.
 
-**Nitrate** (`f_no3(i,j,k)`, $NO_3$, [mol N kg<sup>-1</sup>])
+**Nitrate** (`p_no3(i,j,k,tau)`, $NO_3$, [mol N kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1203,7 +1205,7 @@ $$
 \end{align}
 $$
 
-**Oxygen** (`f_o2(i,j,k)`, $O_2$, [mol O<sub>2</sub> kg<sup>-1</sup>])
+**Oxygen** (`p_o2(i,j,k,tau)`, $O_2$, [mol O<sub>2</sub> kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1212,7 +1214,7 @@ $$
 \end{align}
 $$
 
-**Dissolved iron** (`f_fe(i,j,k)`, $dFe$, [mol Fe kg<sup>-1</sup>])
+**Dissolved iron** (`p_fe(i,j,k,tau)`, $dFe$, [mol Fe kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1224,16 +1226,16 @@ $$
 \end{align}
 $$
 
-**Phytoplankton** (`f_phy(i,j,k)`, $B_{phy}^{C}$, [mol C kg<sup>-1</sup>])
+**Phytoplankton** (`p_phy(i,j,k,tau)`, $B_{phy}^{C}$, [mol C kg<sup>-1</sup>])
 
 $$
 \begin{align}
-\dfrac{\Delta pB_{phy}^{C}y}{\Delta t} =& \quad \mu_{phy}^{\leftarrow C} \\
+\dfrac{\Delta B_{phy}^{C}}{\Delta t} =& \quad \mu_{phy}^{\leftarrow C} \\
                                         & - \left( \Gamma_{phy}^{\rightarrow C} + \gamma_{phy}^{\rightarrow C} + g_{zoo}^{\leftarrow B_{phy}^{C}} \right)
 \end{align}
 $$
 
-**Phytoplankton chlorophyll** (`f_pchl(i,j,k)`, $B_{phy}^{Chl}$, [mol Chl kg<sup>-1</sup>])
+**Phytoplankton chlorophyll** (`p_pchl(i,j,k,tau)`, $B_{phy}^{Chl}$, [mol Chl kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1242,7 +1244,7 @@ $$
 \end{align}
 $$
 
-**Phytoplankton iron** (`f_phyfe(i,j,k)`, $B_{phy}^{Fe}$, [mol Fe kg<sup>-1</sup>])
+**Phytoplankton iron** (`p_phyfe(i,j,k,tau)`, $B_{phy}^{Fe}$, [mol Fe kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1251,7 +1253,7 @@ $$
 \end{align}
 $$
 
-**Zoooplankton** (`f_zoo(i,j,k)`, $B_{zoo}^{C}$, [mol C kg<sup>-1</sup>])
+**Zoooplankton** (`p_zoo(i,j,k,tau)`, $B_{zoo}^{C}$, [mol C kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1259,7 +1261,7 @@ $$
 \end{align}
 $$
 
-**Zoooplankton iron** (`f_zoofe(i,j,k)`, $B_{zoo}^{Fe}$, [mol Fe kg<sup>-1</sup>])
+**Zoooplankton iron** (`p_zoofe(i,j,k,tau)`, $B_{zoo}^{Fe}$, [mol Fe kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1268,7 +1270,7 @@ $$
 \end{align}
 $$
 
-**Detritus** (`f_det(i,j,k)`, $B_{det}^{C}$, [mol C kg<sup>-1</sup>])
+**Detritus** (`p_det(i,j,k,tau)`, $B_{det}^{C}$, [mol C kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1277,7 +1279,7 @@ $$
 \end{align}
 $$
 
-**Detritus iron** (`f_detfe(i,j,k)`, $B_{det}^{Fe}$, [mol Fe kg<sup>-1</sup>])
+**Detritus iron** (`p_detfe(i,j,k,tau)`, $B_{det}^{Fe}$, [mol Fe kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1289,7 +1291,7 @@ $$
 \end{align}
 $$
 
-**Calcium Carbonate** (`f_caco3(i,j,k)`, $B_{CaCO_3}^{C}$, [mol C kg<sup>-1</sup>])
+**Calcium Carbonate** (`p_caco3(i,j,k,tau)`, $B_{CaCO_3}^{C}$, [mol C kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1304,7 +1306,7 @@ $$
 \end{align}
 $$
 
-**Dissolved Inorganic Carbon** (`f_dic(i,j,k)`, $DIC$, [mol C kg<sup>-1</sup>])
+**Dissolved Inorganic Carbon** (`p_dic(i,j,k,tau)`, $DIC$, [mol C kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1313,7 +1315,7 @@ $$
 \end{align}
 $$
 
-**Alkalinity** (`f_alk(i,j,k)`, $Alk$, [mol Eq kg<sup>-1</sup>])
+**Alkalinity** (`p_alk(i,j,k,tau)`, $Alk$, [mol Eq kg<sup>-1</sup>])
 
 $$
 \begin{align}
@@ -1336,7 +1338,7 @@ When checks for the conservation of mass is enabled (`do_check_n_conserve = .tru
 
 **First**, dissolved iron concentrations are set to equal 1 nM everywhere where the depth of the water column is less than 200 metres deep. WOMBAT-lite is not considered to be a model of the coastal ocean, but rather a model of the global pelagic ocean. Given that coastal waters are not limited in dissolved iron due to substantial interactions with sediments and exchange with the land, we universally set the dissolved iron concentration in these waters to 1 nM.
 
-**Second**, if dissolved iron concentrations dip below that measureable by operational detection limits, we reset these concentrations to this minimum  (`dfefloor`, $[dFe]^{min}$, [nmol Fe kg<sup>-1</sup>]). $[dFe]^{min}$ is set in the parameter list and is configurable at run time.
+**Second**, if dissolved iron concentrations dip below that measureable by operational detection limits in waters deeper than 200 m, we reset these concentrations to this minimum  (`dfefloor`, $[dFe]^{min}$, [nmol Fe kg<sup>-1</sup>]). $[dFe]^{min}$ is set in the parameter list and is configurable at run time.
 
 ---
 
@@ -1375,7 +1377,7 @@ $$
 
 _where_ <br>
 - $\omega_{det}^{0}$ is the sinking speed of organic detritus produced by a surface phytoplankton concentration of 1 mmol C m<sup>-3</sup> (`wdetbio`, [m s<sup>-1</sup>]) <br>
-- $B_{phy}^{C}$ is the concentration of phytoplankton biomass (`biophy`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C}$ is the concentration of phytoplankton biomass (`phy_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 This formula is identical to that presented by [Cael et al. (2021)](https://doi.org/10.1029/2020GL091771) in their Eq. (3), with the exception that we have related sinking rates to the biomass concentration of phytoplankton ($B_{phy}^{C}$) by assuming that $V = (B_{phy}^{C})^{0.65}$ based on marine phytoplankton data [(Wickman et al., 2024)](https://doi.org/10.1126/science.adk6901).
 
@@ -1396,10 +1398,10 @@ $$
 $$
 
 _where_ <br>
-- $B_{phy}^{C,k=1}$ is the concentration of phytoplankton biomass at the surface (`biophy1`, [mmol C m<sup>-3</sup>]) <br>
+- $B_{phy}^{C,k=1}$ is the concentration of phytoplankton biomass at the surface (`phy_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 - $B_{phy}^{thresh}$ is the phytoplankton biomass threshold above which the community cell size begins to increase (`phybiot`, [mmol C m<sup>-3</sup>]) <br>
-- $B_{CaCO_3}^{C}$ is the in situ concentration of $CaCO_3$ biomass (`f_caco3(i,j,k)`, [mol C kg<sup>-1</sup>]) <br>
-- $B_{det}^{C}$ is the in situ concentration of organic detrital biomass (`f_det(i,j,k)`, [mol C kg<sup>-1</sup>]) <br>
+- $B_{CaCO_3}^{C}$ is the in situ concentration of $CaCO_3$ biomass (`p_caco3(i,j,k,tau)`, [mol C kg<sup>-1</sup>]) <br>
+- $B_{det}^{C}$ is the in situ concentration of organic detrital biomass (`p_det(i,j,k,tau)`, [mol C kg<sup>-1</sup>]) <br>
 
 
 and where we chose a maximum increase of 10 metres per day based on the more modest effect observed in mesocosm experiments ([Bach et al., 2016](https://agupubs.onlinelibrary.wiley.com/doi/10.1002/2016GB005372).

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1,16 +1,23 @@
 !-----------------------------------------------------------------------
 !
+!                       PRIMARY DEVELOPERS
+!
+! <CONTACT EMAIL="Pearse.Buchanan@csiro.au"> Pearse Buchanan
+! </CONTACT>
+!
+! <CONTACT EMAIL="Dougie.Squire@anu.edu.au"> Dougie Squire
+! </CONTACT>
+!
+!
+!                         OTHER CONTACTS
+!
 ! <CONTACT EMAIL="Richard.Matear@csiro.au"> Richard Matear
 ! </CONTACT>
 !
 ! <CONTACT EMAIL="Matthew.Chamberlain@csiro.au"> Matt Chamberlain
 ! </CONTACT>
 !
-! <CONTACT EMAIL="Dougal.Squire@anu.edu.au"> Dougie Squire
-! </CONTACT>
 !
-! <CONTACT EMAIL="Pearse.Buchanan@csiro.au"> Pearse Buchanan
-! </CONTACT>
 !
 ! <OVERVIEW>
 !  This module contains the generic version of WOMBATlite.

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -274,19 +274,8 @@ module generic_WOMBATlite
 
     real, dimension(:,:,:), allocatable :: &
         f_dic, &
-        f_dicr, &
-        f_alk, &
         f_no3, &
-        f_phy, &
-        f_pchl, &
-        f_phyfe, &
-        f_zoo, &
-        f_zoofe, &
-        f_det, &
-        f_detfe, &
-        f_o2, &
-        f_caco3, &
-        f_fe, &
+        f_alk, &
         radbio, &
         radmid, &
         radmld, &
@@ -343,7 +332,20 @@ module generic_WOMBATlite
         zm
 
     real, dimension(:,:,:,:), pointer :: &
-        p_o2
+        p_dic, &
+        p_dicr, &
+        p_alk, &
+        p_no3, &
+        p_phy, &
+        p_pchl, &
+        p_phyfe, &
+        p_zoo, &
+        p_zoofe, &
+        p_det, &
+        p_detfe, &
+        p_o2, &
+        p_caco3, &
+        p_fe
 
     real, dimension(:,:,:), pointer :: &
         p_det_sediment, &
@@ -2240,24 +2242,20 @@ module generic_WOMBATlite
     dtsb = dt / float(ts_npzd) ! number of seconds per nested ecosystem timestep
 
     ! Get the prognostic tracer values
-    ! dts attn: we should probably update prognostic tracers via pointers to avoid
-    ! having to allocate all these field arrays
-    ! dts attn: do we really want/need to force these to be positive?
-    call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'phy', 'field', wombat%f_phy, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'pchl', 'field', wombat%f_pchl, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'phyfe', 'field', wombat%f_phyfe, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'zoo', 'field', wombat%f_zoo, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'zoofe', 'field', wombat%f_zoofe, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'det', 'field', wombat%f_det, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'detfe', 'field', wombat%f_detfe, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'o2', 'field', wombat%f_o2, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'caco3', 'field', wombat%f_caco3, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'fe', 'field', wombat%f_fe, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'dicr', 'field', wombat%f_dicr, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau) ! [mol/kg]
-
+    call g_tracer_get_pointer(tracer_list, 'no3', 'field', wombat%p_no3) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'phy', 'field', wombat%p_phy) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'pchl', 'field', wombat%p_pchl) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'phyfe', 'field', wombat%p_phyfe) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'zoo', 'field', wombat%p_zoo) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'zoofe', 'field', wombat%p_zoofe) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'det', 'field', wombat%p_det) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'detfe', 'field', wombat%p_detfe) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'o2', 'field', wombat%p_o2) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'caco3', 'field', wombat%p_caco3) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'fe', 'field', wombat%p_fe) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'dic', 'field', wombat%p_dic) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'dicr', 'field', wombat%p_dicr) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'alk', 'field', wombat%p_alk) ! [mol/kg]
 
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
@@ -2321,11 +2319,11 @@ module generic_WOMBATlite
       do k = 1,grid_kmt(i,j)  !{
 
         ! chlorophyll concentration conversion from mol/kg --> mg/m3 for look-up table
-        chl = wombat%f_pchl(i,j,k) * 12.0 / mmol_m3_to_mol_kg
+        chl = wombat%p_pchl(i,j,k,tau) * 12.0 / mmol_m3_to_mol_kg
         ! detritus concentration conversion from mol/kg --> mgN/m3 for look-up table
-        ndet = max(0.0, wombat%f_det(i,j,k)) * 16.0/122.0 * 14.0 / mmol_m3_to_mol_kg
+        ndet = max(0.0, wombat%p_det(i,j,k,tau)) * 16.0/122.0 * 14.0 / mmol_m3_to_mol_kg
         ! CaCO3 concentration conversion from mol/kg --> kg/m3 for look-up table
-        carb = max(0.0, wombat%f_caco3(i,j,k)) / mmol_m3_to_mol_kg * 100.09 * 1e-3 * 1e-3 ! convert to kg/m3
+        carb = max(0.0, wombat%p_caco3(i,j,k,tau)) / mmol_m3_to_mol_kg * 100.09 * 1e-3 * 1e-3 ! convert to kg/m3
 
         ! Attenuation coefficients given chlorophyll concentration
         zchl = max(0.05, min(10.0, chl) )
@@ -2425,18 +2423,18 @@ module generic_WOMBATlite
       ! Initialise some floored values and ratios (put into nicer units than mol/kg)
       ! Loss/source coefficients are calculated using the floored values but are applied to the
       ! un-floored tracer values
-      phy_p = max(0.0, wombat%f_phy(i,j,k))
-      phyfe_p = max(0.0, wombat%f_phyfe(i,j,k))
-      pchl_p = max(0.0, wombat%f_pchl(i,j,k))
-      zoo_p = max(0.0, wombat%f_zoo(i,j,k))
-      det_p = max(0.0, wombat%f_det(i,j,k))
+      phy_p = max(0.0, wombat%p_phy(i,j,k,tau))
+      phyfe_p = max(0.0, wombat%p_phyfe(i,j,k,tau))
+      pchl_p = max(0.0, wombat%p_pchl(i,j,k,tau))
+      zoo_p = max(0.0, wombat%p_zoo(i,j,k,tau))
+      det_p = max(0.0, wombat%p_det(i,j,k,tau))
       phy_mmolm3 = phy_p / mmol_m3_to_mol_kg ! [mmol/m3]
       phyfe_mmolm3 = phyfe_p / mmol_m3_to_mol_kg ! [mmol/m3]
       zoo_mmolm3 = zoo_p / mmol_m3_to_mol_kg ! [mmol/m3]
       det_mmolm3 = det_p / mmol_m3_to_mol_kg ! [mmol/m3]
-      no3_mmolm3 = max(0.0, wombat%f_no3(i,j,k)) / mmol_m3_to_mol_kg ! [mmol/m3]
-      fe_umolm3 = max(0.0, wombat%f_fe(i,j,k)) / umol_m3_to_mol_kg ![umol/m3]
-      caco3_mmolm3 = max(0.0, wombat%f_caco3(i,j,k)) / mmol_m3_to_mol_kg ![mmol/m3]
+      no3_mmolm3 = max(0.0, wombat%p_no3(i,j,k,tau)) / mmol_m3_to_mol_kg ! [mmol/m3]
+      fe_umolm3 = max(0.0, wombat%p_fe(i,j,k,tau)) / umol_m3_to_mol_kg ![umol/m3]
+      caco3_mmolm3 = max(0.0, wombat%p_caco3(i,j,k,tau)) / mmol_m3_to_mol_kg ![mmol/m3]
       ! Only calculate these ratios when the denominator is > 0.0, else 0.0
       if (phy_p > 0.0) then
         phy_chlc = pchl_p / phy_p
@@ -2446,12 +2444,12 @@ module generic_WOMBATlite
         phy_Fe2C = 0.0
       endif
       if (zoo_p > 0.0) then
-        zoo_Fe2C = max(0.0, wombat%f_zoofe(i,j,k)) / zoo_p
+        zoo_Fe2C = max(0.0, wombat%p_zoofe(i,j,k,tau)) / zoo_p
       else
         zoo_Fe2C = 0.0
       endif
       if (det_p > 0.0) then
-        det_Fe2C = max(0.0, wombat%f_detfe(i,j,k)) / det_p
+        det_Fe2C = max(0.0, wombat%p_detfe(i,j,k,tau)) / det_p
       else
         det_Fe2C = 0.0
       endif
@@ -2521,7 +2519,7 @@ module generic_WOMBATlite
       wombat%phy_mu(i,j,k) = wombat%phy_mumax(i,j,k) * wombat%phy_lpar(i,j,k) * &
                              min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))
 
-      if (wombat%f_no3(i,j,k) > epsi) then
+      if (wombat%p_no3(i,j,k,tau) > epsi) then
         wombat%phygrow(i,j,k) = wombat%phy_mu(i,j,k) * phy_p ! [molC/kg/s]
       else
         wombat%phygrow(i,j,k) = 0.0
@@ -2567,7 +2565,7 @@ module generic_WOMBATlite
       ! 2. Ensure that dFe uptake increases or decreases in response to cell quota
       ! 3. Iron uptake of phytoplankton (reduced 10-fold in darkness)
 
-      if (wombat%f_phy(i,j,k) > epsi) then
+      if (wombat%p_phy(i,j,k,tau) > epsi) then
         phy_maxqfe = phy_mmolm3 * wombat%phymaxqf  !mmol Fe / m3
         wombat%phy_feupreg(i,j,k) = (4.0 - 4.5 * wombat%phy_lfer(i,j,k) / &
                                     (wombat%phy_lfer(i,j,k) + 0.5) )
@@ -2800,7 +2798,7 @@ module generic_WOMBATlite
         !  HCO3- to free H+ ions ratio (mol/umol), following Lehmann & Bach (2024).
         !  We also add a T-dependent function to scale down CaCO3 production in waters colder
         !  than 3 degrees C based off the observation of no E hux growth beneath this (Fielding 2013; L&O)
-        hco3 = wombat%f_dic(i,j,k) - wombat%co3(i,j,k) - wombat%co2_star(i,j,k)
+        hco3 = wombat%p_dic(i,j,k,tau) - wombat%co3(i,j,k) - wombat%co2_star(i,j,k)
         ! Note the min(2.0, ...) in the exponent is just to prevent potential overflow. It does
         ! not affect answers as pic2poc is capped at 0.3
         wombat%pic2poc(i,j,k) = min(0.3, (wombat%f_inorg + 10.0**(min(2.0, -3.0 + 4.31e-6 * &
@@ -2837,19 +2835,19 @@ module generic_WOMBATlite
                 wombat%zoograzphy(i,j,k)
       if (phy_mmolm3 > 1e-3) then
         ! Treat phymorq semi-implicitly
-        k_loss = wombat%phyqmor / mmol_m3_to_mol_kg * wombat%f_phy(i,j,k)
-        wombat%f_phy(i,j,k) = (wombat%f_phy(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
+        k_loss = wombat%phyqmor / mmol_m3_to_mol_kg * wombat%p_phy(i,j,k,tau)
+        wombat%p_phy(i,j,k,tau) = (wombat%p_phy(i,j,k,tau) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
 
         ! Back-calculate phymorq for use below and for diagnostic output
-        wombat%phymorq(i,j,k) = k_loss * wombat%f_phy(i,j,k) ! [molC/kg/s]
+        wombat%phymorq(i,j,k) = k_loss * wombat%p_phy(i,j,k,tau) ! [molC/kg/s]
       else
-        wombat%f_phy(i,j,k) = wombat%f_phy(i,j,k) + dtsb * P_expl
+        wombat%p_phy(i,j,k,tau) = wombat%p_phy(i,j,k,tau) + dtsb * P_expl
         wombat%phymorq(i,j,k) = 0.0
       endif
 
       ! Phytoplankton chlorophyll equation ! [molChl/kg]
       !-----------------------------------------------------------------------
-      wombat%f_pchl(i,j,k)  = wombat%f_pchl(i,j,k) + dtsb * ( &
+      wombat%p_pchl(i,j,k,tau)  = wombat%p_pchl(i,j,k,tau) + dtsb * ( &
                                 wombat%pchl_mu(i,j,k) - &
                                 wombat%phymorl(i,j,k) * phy_chlc - &
                                 wombat%phymorq(i,j,k) * phy_chlc - &
@@ -2857,7 +2855,7 @@ module generic_WOMBATlite
 
       ! Phytoplankton iron equation ! [molFe/kg]
       !-----------------------------------------------------------------------
-      wombat%f_phyfe(i,j,k)  = wombat%f_phyfe(i,j,k) + dtsb * ( &
+      wombat%p_phyfe(i,j,k,tau)  = wombat%p_phyfe(i,j,k,tau) + dtsb * ( &
                                  wombat%phy_dfeupt(i,j,k) - &
                                  wombat%phymorl(i,j,k) * phy_Fe2C - &
                                  wombat%phymorq(i,j,k) * phy_Fe2C - &
@@ -2875,19 +2873,19 @@ module generic_WOMBATlite
                 wombat%zoomorl(i,j,k)
       if (zoo_mmolm3 > 1e-3) then
         ! Treat zoomorq semi-implicitly
-        k_loss = wombat%zooqmor / mmol_m3_to_mol_kg * wombat%f_zoo(i,j,k)
-        wombat%f_zoo(i,j,k) = (wombat%f_zoo(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
+        k_loss = wombat%zooqmor / mmol_m3_to_mol_kg * wombat%p_zoo(i,j,k,tau)
+        wombat%p_zoo(i,j,k,tau) = (wombat%p_zoo(i,j,k,tau) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
 
         ! Back-calculate zoomorq for use below and diagnostic output
-        wombat%zoomorq(i,j,k) = k_loss * wombat%f_zoo(i,j,k) ! [molC/kg/s]
+        wombat%zoomorq(i,j,k) = k_loss * wombat%p_zoo(i,j,k,tau) ! [molC/kg/s]
       else
-        wombat%f_zoo(i,j,k) = wombat%f_zoo(i,j,k) + dtsb * P_expl
+        wombat%p_zoo(i,j,k,tau) = wombat%p_zoo(i,j,k,tau) + dtsb * P_expl
         wombat%zoomorq(i,j,k) = 0.0
       endif
 
       ! Zooplankton iron equation ! [molFe/kg]
       !-----------------------------------------------------------------------
-      wombat%f_zoofe(i,j,k)  = wombat%f_zoofe(i,j,k) + dtsb * ( &
+      wombat%p_zoofe(i,j,k,tau)  = wombat%p_zoofe(i,j,k,tau) + dtsb * ( &
                                  zooassiphyfe + &
                                  zooassidetfe - &
                                  wombat%zoomorl(i,j,k) * zoo_Fe2C - &
@@ -2907,21 +2905,21 @@ module generic_WOMBATlite
                 wombat%phymorq(i,j,k) + &
                 wombat%zoomorq(i,j,k) - &
                 wombat%zoograzdet(i,j,k)
-      if (wombat%f_det(i,j,k) > epsi) then
+      if (wombat%p_det(i,j,k,tau) > epsi) then
         ! Treat detremi semi-implicitly
-        k_loss = wombat%reminr(i,j,k) / mmol_m3_to_mol_kg * wombat%f_det(i,j,k)
-        wombat%f_det(i,j,k) = (wombat%f_det(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
+        k_loss = wombat%reminr(i,j,k) / mmol_m3_to_mol_kg * wombat%p_det(i,j,k,tau)
+        wombat%p_det(i,j,k,tau) = (wombat%p_det(i,j,k,tau) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
 
         ! Back-calculate detremi for use below and diagnostic output
-        wombat%detremi(i,j,k) = k_loss * wombat%f_det(i,j,k) ! [molC/kg/s]
+        wombat%detremi(i,j,k) = k_loss * wombat%p_det(i,j,k,tau) ! [molC/kg/s]
       else
-        wombat%f_det(i,j,k) = wombat%f_det(i,j,k) + dtsb * P_expl
+        wombat%p_det(i,j,k,tau) = wombat%p_det(i,j,k,tau) + dtsb * P_expl
         wombat%detremi(i,j,k) = 0.0
       endif
 
       ! Nitrate equation ! [molN/kg]
       !----------------------------------------------------------------------
-      wombat%f_no3(i,j,k) = wombat%f_no3(i,j,k) + dtsb * 16./122. * ( &
+      wombat%p_no3(i,j,k,tau) = wombat%p_no3(i,j,k,tau) + dtsb * 16./122. * ( &
                               wombat%detremi(i,j,k) + &
                               wombat%zoomorl(i,j,k) + &
                               wombat%zooexcrphy(i,j,k) + &
@@ -2931,7 +2929,7 @@ module generic_WOMBATlite
 
       ! Detrital iron equation ! [molFe/kg]
       !-----------------------------------------------------------------------
-      wombat%f_detfe(i,j,k) = wombat%f_detfe(i,j,k) + dtsb * ( &
+      wombat%p_detfe(i,j,k,tau) = wombat%p_detfe(i,j,k,tau) + dtsb * ( &
                                 zooegesphyfe + &
                                 zooegesdetfe + &
                                 wombat%phymorq(i,j,k) * phy_Fe2C + &
@@ -2943,8 +2941,8 @@ module generic_WOMBATlite
 
       ! Oxygen equation ! [molO2/kg]
       !-----------------------------------------------------------------------
-      if (wombat%f_o2(i,j,k) > epsi) &
-        wombat%f_o2(i,j,k) = wombat%f_o2(i,j,k) - 172./122. * dtsb * ( &
+      if (wombat%p_o2(i,j,k,tau) > epsi) &
+        wombat%p_o2(i,j,k,tau) = wombat%p_o2(i,j,k,tau) - 172./122. * dtsb * ( &
                                wombat%detremi(i,j,k) + &
                                wombat%zoomorl(i,j,k) + &
                                wombat%zooexcrphy(i,j,k) + &
@@ -2960,20 +2958,20 @@ module generic_WOMBATlite
       P_expl = wombat%phymorq(i,j,k) * wombat%pic2poc(i,j,k) + &
                 wombat%zoomorq(i,j,k) * wombat%pic2poc(i,j,k) + &
                 wombat%zoograzphy(i,j,k) * (1. - wombat%fgutdiss) * wombat%pic2poc(i,j,k)
-      if (wombat%f_caco3(i,j,k) > epsi) then
+      if (wombat%p_caco3(i,j,k,tau) > epsi) then
           ! Treat loss terms that are proportional to CaCO3 concentration implicitly
           k_loss_zoodiss = wombat%zoograzdet(i,j,k) * wombat%fgutdiss / max(epsi, det_p)
           k_loss = wombat%dissratcal(i,j,k) + wombat%dissratara(i,j,k) + wombat%dissratpoc(i,j,k) &
                         + k_loss_zoodiss
-          wombat%f_caco3(i,j,k) = (wombat%f_caco3(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
+          wombat%p_caco3(i,j,k,tau) = (wombat%p_caco3(i,j,k,tau) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
 
           ! Back-calculate the dissolution terms for use below and diagnostic output
-          wombat%zoodiss(i,j,k) = k_loss_zoodiss * wombat%f_caco3(i,j,k)
-          wombat%caldiss(i,j,k) = wombat%dissratcal(i,j,k) * wombat%f_caco3(i,j,k)
-          wombat%aradiss(i,j,k) = wombat%dissratara(i,j,k) * wombat%f_caco3(i,j,k)
-          wombat%pocdiss(i,j,k) = wombat%dissratpoc(i,j,k) * wombat%f_caco3(i,j,k)
+          wombat%zoodiss(i,j,k) = k_loss_zoodiss * wombat%p_caco3(i,j,k,tau)
+          wombat%caldiss(i,j,k) = wombat%dissratcal(i,j,k) * wombat%p_caco3(i,j,k,tau)
+          wombat%aradiss(i,j,k) = wombat%dissratara(i,j,k) * wombat%p_caco3(i,j,k,tau)
+          wombat%pocdiss(i,j,k) = wombat%dissratpoc(i,j,k) * wombat%p_caco3(i,j,k,tau)
       else
-          wombat%f_caco3(i,j,k) = wombat%f_caco3(i,j,k) + dtsb * P_expl
+          wombat%p_caco3(i,j,k,tau) = wombat%p_caco3(i,j,k,tau) + dtsb * P_expl
           wombat%zoodiss(i,j,k) = 0.0
           wombat%caldiss(i,j,k) = 0.0
           wombat%aradiss(i,j,k) = 0.0
@@ -2982,7 +2980,7 @@ module generic_WOMBATlite
 
       ! Equation for DIC ! [molC/kg]
       !-----------------------------------------------------------------------
-      wombat%f_dic(i,j,k) = wombat%f_dic(i,j,k) + dtsb * ( &
+      wombat%p_dic(i,j,k,tau) = wombat%p_dic(i,j,k,tau) + dtsb * ( &
                               wombat%detremi(i,j,k) + &
                               wombat%zoomorl(i,j,k) + &
                               wombat%zooexcrphy(i,j,k) + &
@@ -2997,7 +2995,7 @@ module generic_WOMBATlite
 
       ! Equation for DICr ! [molC/kg]
       !-----------------------------------------------------------------------
-      wombat%f_dicr(i,j,k) = wombat%f_dicr(i,j,k) + dtsb * ( &
+      wombat%p_dicr(i,j,k,tau) = wombat%p_dicr(i,j,k,tau) + dtsb * ( &
                                wombat%detremi(i,j,k) + &
                                wombat%zoomorl(i,j,k) + &
                                wombat%zooexcrphy(i,j,k) + &
@@ -3012,7 +3010,7 @@ module generic_WOMBATlite
 
       ! Equation for ALK ! [molC/kg]
       !-----------------------------------------------------------------------
-      wombat%f_alk(i,j,k) = wombat%f_alk(i,j,k) + dtsb * 16.0/122.0 * ( &
+      wombat%p_alk(i,j,k,tau) = wombat%p_alk(i,j,k,tau) + dtsb * 16.0/122.0 * ( &
                               wombat%phygrow(i,j,k) - &
                               wombat%detremi(i,j,k) - &
                               wombat%zoomorl(i,j,k) - &
@@ -3027,7 +3025,7 @@ module generic_WOMBATlite
 
       ! Extra equation for iron ! [molFe/kg]
       !-----------------------------------------------------------------------
-      wombat%f_fe(i,j,k) = wombat%f_fe(i,j,k) + dtsb * ( &
+      wombat%p_fe(i,j,k,tau) = wombat%p_fe(i,j,k,tau) + dtsb * ( &
                              wombat%detremi(i,j,k) * det_Fe2C + &
                              wombat%zoomorl(i,j,k) * zoo_Fe2C + &
                              zooexcrphyfe + &
@@ -3060,10 +3058,10 @@ module generic_WOMBATlite
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
 
-      n_pools(i,j,k,2) = wombat%f_no3(i,j,k) + (wombat%f_phy(i,j,k) + wombat%f_det(i,j,k) + &
-                          wombat%f_zoo(i,j,k)) * 16/122.0
-      c_pools(i,j,k,2) = wombat%f_dic(i,j,k) + wombat%f_phy(i,j,k) + wombat%f_det(i,j,k) + &
-                         wombat%f_zoo(i,j,k) + wombat%f_caco3(i,j,k)
+      n_pools(i,j,k,2) = wombat%p_no3(i,j,k,tau) + (wombat%p_phy(i,j,k,tau) + wombat%p_det(i,j,k,tau) + &
+                          wombat%p_zoo(i,j,k,tau)) * 16/122.0
+      c_pools(i,j,k,2) = wombat%p_dic(i,j,k,tau) + wombat%p_phy(i,j,k,tau) + wombat%p_det(i,j,k,tau) + &
+                         wombat%p_zoo(i,j,k,tau) + wombat%p_caco3(i,j,k,tau)
 
       if (tn>1) then
         if (do_check_n_conserve) then
@@ -3078,10 +3076,10 @@ module generic_WOMBATlite
             print *, "       Biological N budget (molN/kg) at two timesteps =", n_pools(i,j,k,1), n_pools(i,j,k,2)
             print *, "       Difference in budget between timesteps =", n_pools(i,j,k,2) - n_pools(i,j,k,1)
             print *, " "
-            print *, "       NO3 (molNO3/kg) =", wombat%f_no3(i,j,k)
-            print *, "       PHY (molN/kg) =", wombat%f_phy(i,j,k) * 16.0 / 122.0
-            print *, "       ZOO (molN/kg) =", wombat%f_zoo(i,j,k) * 16.0 / 122.0
-            print *, "       DET (molN/kg) =", wombat%f_det(i,j,k) * 16.0 / 122.0
+            print *, "       NO3 (molNO3/kg) =", wombat%p_no3(i,j,k,tau)
+            print *, "       PHY (molN/kg) =", wombat%p_phy(i,j,k,tau) * 16.0 / 122.0
+            print *, "       ZOO (molN/kg) =", wombat%p_zoo(i,j,k,tau) * 16.0 / 122.0
+            print *, "       DET (molN/kg) =", wombat%p_det(i,j,k,tau) * 16.0 / 122.0
             print *, " "
             print *, "--------------------------------------------"
             call mpp_error(FATAL, trim(error_header) // " Terminating run due to non-conservation of tracer")
@@ -3099,12 +3097,12 @@ module generic_WOMBATlite
             print *, "       Biological C budget (molC/kg) at two timesteps =", c_pools(i,j,k,1), c_pools(i,j,k,2)
             print *, "       Difference in budget between timesteps =", c_pools(i,j,k,2) - c_pools(i,j,k,1)
             print *, " "
-            print *, "       DIC (molC/kg) =", wombat%f_dic(i,j,k)
-            print *, "       ALK (molC/kg) =", wombat%f_alk(i,j,k)
-            print *, "       PHY (molC/kg) =", wombat%f_phy(i,j,k)
-            print *, "       ZOO (molC/kg) =", wombat%f_zoo(i,j,k)
-            print *, "       DET (molC/kg) =", wombat%f_det(i,j,k)
-            print *, "       CaCO3 (molC/kg) =", wombat%f_caco3(i,j,k)
+            print *, "       DIC (molC/kg) =", wombat%p_dic(i,j,k,tau)
+            print *, "       ALK (molC/kg) =", wombat%p_alk(i,j,k,tau)
+            print *, "       PHY (molC/kg) =", wombat%p_phy(i,j,k,tau)
+            print *, "       ZOO (molC/kg) =", wombat%p_zoo(i,j,k,tau)
+            print *, "       DET (molC/kg) =", wombat%p_det(i,j,k,tau)
+            print *, "       CaCO3 (molC/kg) =", wombat%p_caco3(i,j,k,tau)
             print *, "       Temp =", Temp(i,j,k)
             print *, "       Salt =", Salt(i,j,k)
             print *, "       surface pCO2 =", wombat%pco2_csurf(i,j)
@@ -3143,7 +3141,7 @@ module generic_WOMBATlite
       ! mac: bottom dFe fix to 1 nM when the water is <= 200 m deep.
       if (grid_kmt(i,j) > 0) then
         k = grid_kmt(i,j)
-        if (wombat%zw(i,j,k) <= 200) wombat%f_fe(i,j,k)= umol_m3_to_mol_kg * 0.999 ! [mol/kg]
+        if (wombat%zw(i,j,k) <= 200) wombat%p_fe(i,j,k,tau) = umol_m3_to_mol_kg * 0.999 ! [mol/kg]
       endif
       do k = 1,nk
         ! pjb: tune minimum dissolved iron concentration to detection limit...
@@ -3152,28 +3150,11 @@ module generic_WOMBATlite
         ! Only do this where the ocean is > 200m deep to avoid truncating negative tracer concentrations
         ! at river mouths
         if (wombat%zw(i,j,k) > 200) then
-          wombat%f_fe(i,j,k) = max(wombat%dfefloor * umol_m3_to_mol_kg, &
-                                wombat%f_fe(i,j,k)) * grid_tmask(i,j,k)
+          wombat%p_fe(i,j,k,tau) = max(wombat%dfefloor * umol_m3_to_mol_kg, &
+                                wombat%p_fe(i,j,k,tau)) * grid_tmask(i,j,k)
         endif
       enddo
     enddo; enddo
-
-
-    ! Set tracers values
-    call g_tracer_set_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'phy', 'field', wombat%f_phy, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'pchl', 'field', wombat%f_pchl, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'phyfe', 'field', wombat%f_phyfe, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'zoo', 'field', wombat%f_zoo, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'zoofe', 'field', wombat%f_zoofe, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'det', 'field', wombat%f_det, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'detfe', 'field', wombat%f_detfe, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'o2', 'field', wombat%f_o2, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'caco3', 'field', wombat%f_caco3, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'fe', 'field', wombat%f_fe, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'dicr', 'field', wombat%f_dicr, isd, jsd, ntau=tau)
-    call g_tracer_set_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau)
 
 
     !-----------------------------------------------------------------------!
@@ -3194,12 +3175,12 @@ module generic_WOMBATlite
     ! crossing within a timestep
     do j = jsc,jec; do i = isc,iec;
       if (grid_kmt(i,j)>0) then
-        phy_mmolm3  = wombat%f_phy(i,j,1) / mmol_m3_to_mol_kg ! [mmol/m3]
+        phy_mmolm3  = wombat%p_phy(i,j,1,tau) / mmol_m3_to_mol_kg ! [mmol/m3]
         wsink(:) = wombat%wdetbio * max(0.0, phy_mmolm3 - wombat%phybiot)**(0.21)
         do k=1,nk
           wsink(k) = wsink(k) + 10.0/86400.0 * min(1.0, &
-                     (max(0.0, wombat%f_caco3(i,j,k)) / &
-                     (max(0.0, wombat%f_det(i,j,k)) + max(0.0, wombat%f_caco3(i,j,k)) + epsi)))
+                     (max(0.0, wombat%p_caco3(i,j,k,tau)) / &
+                     (max(0.0, wombat%p_det(i,j,k,tau)) + max(0.0, wombat%p_caco3(i,j,k,tau)) + epsi)))
           ! Increase sinking rate with depth to achieve power law behaviour
           wsink(k) = wsink(k) + max(0.0, wombat%zw(i,j,k)/5000.0 * (wombat%wdetmax - wsink(k)))
           ! CaCO3 sinks slower than general detritus because it tends to be smaller
@@ -3243,9 +3224,9 @@ module generic_WOMBATlite
             dzt_bot = dzt_bot + dzt(i,j,k) ! [m]
             wombat%sedtemp(i,j) = wombat%sedtemp(i,j) + Temp(i,j,k) * dzt(i,j,k) ! [m*degC]
             wombat%sedsalt(i,j) = wombat%sedsalt(i,j) + Salt(i,j,k) * dzt(i,j,k) ! [m*psu]
-            wombat%sedno3(i,j) = wombat%sedno3(i,j) + wombat%f_no3(i,j,k) * dzt(i,j,k) ! [m*mol/kg]
-            wombat%seddic(i,j) = wombat%seddic(i,j) + wombat%f_dic(i,j,k) * dzt(i,j,k) ! [m*mol/kg]
-            wombat%sedalk(i,j) = wombat%sedalk(i,j) + wombat%f_alk(i,j,k) * dzt(i,j,k) ! [m*mol/kg]
+            wombat%sedno3(i,j) = wombat%sedno3(i,j) + wombat%p_no3(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
+            wombat%seddic(i,j) = wombat%seddic(i,j) + wombat%p_dic(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
+            wombat%sedalk(i,j) = wombat%sedalk(i,j) + wombat%p_alk(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
             wombat%sedhtotal(i,j) = wombat%sedhtotal(i,j) + wombat%htotal(i,j,k) * dzt(i,j,k) ! [m*mol/kg]
             endif
         enddo
@@ -3253,9 +3234,9 @@ module generic_WOMBATlite
         dzt_bot_os = dzt_bot - wombat%bottom_thickness
         wombat%sedtemp(i,j) = wombat%sedtemp(i,j) - Temp(i,j,k_bot) * dzt_bot_os ! [m*degC]
         wombat%sedsalt(i,j) = wombat%sedsalt(i,j) - Salt(i,j,k_bot) * dzt_bot_os ! [m*psu]
-        wombat%sedno3(i,j) = wombat%sedno3(i,j) - wombat%f_no3(i,j,k_bot) * dzt_bot_os ! [m*mol/kg]
-        wombat%seddic(i,j) = wombat%seddic(i,j) - wombat%f_dic(i,j,k_bot) * dzt_bot_os ! [m*mol/kg]
-        wombat%sedalk(i,j) = wombat%sedalk(i,j) - wombat%f_alk(i,j,k_bot) * dzt_bot_os ! [m*mol/kg]
+        wombat%sedno3(i,j) = wombat%sedno3(i,j) - wombat%p_no3(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
+        wombat%seddic(i,j) = wombat%seddic(i,j) - wombat%p_dic(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
+        wombat%sedalk(i,j) = wombat%sedalk(i,j) - wombat%p_alk(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
         wombat%sedhtotal(i,j) = wombat%sedhtotal(i,j) - wombat%htotal(i,j,k_bot) * dzt_bot_os ! [m*mol/kg]
         ! Convert to mol/kg
         wombat%sedtemp(i,j) = wombat%sedtemp(i,j) / wombat%bottom_thickness ! [degC]
@@ -3906,19 +3887,8 @@ module generic_WOMBATlite
     allocate(wombat%alk_vstf(isd:ied, jsd:jed)); wombat%alk_vstf(:,:)=0.0
 
     allocate(wombat%f_dic(isd:ied, jsd:jed, 1:nk)); wombat%f_dic(:,:,:)=0.0
-    allocate(wombat%f_dicr(isd:ied, jsd:jed, 1:nk)); wombat%f_dicr(:,:,:)=0.0
-    allocate(wombat%f_alk(isd:ied, jsd:jed, 1:nk)); wombat%f_alk(:,:,:)=0.0
     allocate(wombat%f_no3(isd:ied, jsd:jed, 1:nk)); wombat%f_no3(:,:,:)=0.0
-    allocate(wombat%f_phy(isd:ied, jsd:jed, 1:nk)); wombat%f_phy(:,:,:)=0.0
-    allocate(wombat%f_pchl(isd:ied, jsd:jed, 1:nk)); wombat%f_pchl(:,:,:)=0.0
-    allocate(wombat%f_phyfe(isd:ied, jsd:jed, 1:nk)); wombat%f_phyfe(:,:,:)=0.0
-    allocate(wombat%f_zoo(isd:ied, jsd:jed, 1:nk)); wombat%f_zoo(:,:,:)=0.0
-    allocate(wombat%f_zoofe(isd:ied, jsd:jed, 1:nk)); wombat%f_zoofe(:,:,:)=0.0
-    allocate(wombat%f_det(isd:ied, jsd:jed, 1:nk)); wombat%f_det(:,:,:)=0.0
-    allocate(wombat%f_detfe(isd:ied, jsd:jed, 1:nk)); wombat%f_detfe(:,:,:)=0.0
-    allocate(wombat%f_o2(isd:ied, jsd:jed, 1:nk)); wombat%f_o2(:,:,:)=0.0
-    allocate(wombat%f_caco3(isd:ied, jsd:jed, 1:nk)); wombat%f_caco3(:,:,:)=0.0
-    allocate(wombat%f_fe(isd:ied, jsd:jed, 1:nk)); wombat%f_fe(:,:,:)=0.0
+    allocate(wombat%f_alk(isd:ied, jsd:jed, 1:nk)); wombat%f_alk(:,:,:)=0.0
 
     allocate(wombat%b_no3(isd:ied, jsd:jed)); wombat%b_no3(:,:)=0.0
     allocate(wombat%b_o2(isd:ied, jsd:jed)); wombat%b_o2(:,:)=0.0
@@ -4031,19 +4001,8 @@ module generic_WOMBATlite
 
     deallocate( &
         wombat%f_dic, &
-        wombat%f_dicr, &
-        wombat%f_alk, &
         wombat%f_no3, &
-        wombat%f_phy, &
-        wombat%f_pchl, &
-        wombat%f_phyfe, &
-        wombat%f_zoo, &
-        wombat%f_zoofe, &
-        wombat%f_det, &
-        wombat%f_detfe, &
-        wombat%f_o2, &
-        wombat%f_caco3, &
-        wombat%f_fe)
+        wombat%f_alk)
 
     deallocate( &
         wombat%b_no3, &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2797,7 +2797,7 @@ module generic_WOMBATlite
       !  - the idea is to enrich fecal pellets in iron compared to carbon
       !  1. zooplankton ingest C and Fe (the rest is egested)
       !  2. zooplankton assimilate the ingested C and Fe (the rest is excreted)
-      if (zooprey>1e-3) then
+      if (zooprey > 1e-10) then
         wombat%zoograzphy(i,j,k) = g_npz * zoo_p * (wombat%zooprefphy(i,j,k) * phy_mmolm3) / zooprey ! [molC/kg/s]
         wombat%zoograzdet(i,j,k) = g_npz * zoo_p * (wombat%zooprefdet(i,j,k) * det_mmolm3) / zooprey ! [molC/kg/s]
       else
@@ -2868,7 +2868,7 @@ module generic_WOMBATlite
       P_expl = wombat%phygrow(i,j,k) - &
                 wombat%phymorl(i,j,k) - &
                 wombat%zoograzphy(i,j,k)
-      if (phy_mmolm3 > 1e-3) then
+      if (phy_mmolm3 > 1e-10) then
         ! Treat phymorq semi-implicitly
         k_loss = wombat%phyqmor / mmol_m3_to_mol_kg * wombat%p_phy(i,j,k,tau)
         wombat%p_phy(i,j,k,tau) = (wombat%p_phy(i,j,k,tau) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
@@ -2906,7 +2906,7 @@ module generic_WOMBATlite
       P_expl = wombat%zooassiphy(i,j,k) + &
                 wombat%zooassidet(i,j,k) - &
                 wombat%zoomorl(i,j,k)
-      if (zoo_mmolm3 > 1e-3) then
+      if (zoo_mmolm3 > 1e-10) then
         ! Treat zoomorq semi-implicitly
         k_loss = wombat%zooqmor / mmol_m3_to_mol_kg * wombat%p_zoo(i,j,k,tau)
         wombat%p_zoo(i,j,k,tau) = (wombat%p_zoo(i,j,k,tau) + dtsb * P_expl) / (1.0 + dtsb * k_loss)

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -76,6 +76,14 @@
 !   If true, permanently bury organics and CaCO3 in sediments
 !  </DATA>
 !
+!  <DATA NAME="do_tracer_dicp" TYPE="logical">
+!   If true, do carry preformed dissolved inorganic carbon (dicp) as a tracer
+!  </DATA>
+!
+!  <DATA NAME="do_tracer_dicr" TYPE="logical">
+!   If true, do carry remineralised dissolved inorganic carbon (dicr) as a tracer
+!  </DATA>
+!
 !  <DATA NAME="do_check_n_conserve" TYPE="logical">
 !   If true, check that the ecosystem model conserves nitrogen. NOTE:
 !   not appropriate if dentirification, anammox and nitrogen fixation are on.
@@ -138,6 +146,8 @@ module generic_WOMBATlite
   logical :: do_colloidal_shunt  = .true.  ! do colloidal shunt and coagulation to authigenic pools?
   logical :: do_two_ligands      = .false. ! do two ligands (one strong, one weak) for iron complexation?
   logical :: do_burial           = .false. ! permanently bury organics and CaCO3 in sediments?
+  logical :: do_tracer_dicp      = .false.  ! enable preformed dissolved inorganic carbon tracer, dicp?
+  logical :: do_tracer_dicr      = .false.  ! enable remineralised dissolved inorganic carbon tracer dicr?
   logical :: do_check_n_conserve = .true.  ! check that the N fluxes balance in the ecosystem
   logical :: do_check_c_conserve = .true.  ! check that the C fluxes balance in the ecosystem
 
@@ -542,6 +552,16 @@ module generic_WOMBATlite
           'Permanently burying organics and CaCO3 in sediments'
     endif
 
+    if (do_tracer_dicp) then
+      write (stdoutunit,*) trim(note_header), &
+          'Including preformed dissolved inorganic carbon tracer, dicp'
+    endif
+
+    if (do_tracer_dicr) then
+      write (stdoutunit,*) trim(note_header), &
+          'Including remineralised dissolved inorganic carbon tracer, dicr'
+    endif
+
     if (do_check_n_conserve) then
       write (stdoutunit,*) trim(note_header), &
           'Checking that the ecosystem model conserves nitrogen'
@@ -710,11 +730,13 @@ module generic_WOMBATlite
     wombat%id_dic_vstf = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
-    vardesc_temp = vardesc( &
-        'dicp_vstf', 'Virtual flux of preformed dissolved inorganic carbon into ocean due to '// &
-        'salinity restoring/correction', 'h', '1', 's', 'mol/m^2/s', 'f')
-    wombat%id_dicp_vstf = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
-        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+    if (do_tracer_dicp) then
+      vardesc_temp = vardesc( &
+          'dicp_vstf', 'Virtual flux of preformed dissolved inorganic carbon into ocean due to '// &
+          'salinity restoring/correction', 'h', '1', 's', 'mol/m^2/s', 'f')
+      wombat%id_dicp_vstf = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+          init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+    endif
 
     vardesc_temp = vardesc( &
         'alk_vstf', 'Virtual flux of alkalinity into ocean due to salinity restoring/correction', &
@@ -1623,21 +1645,25 @@ module generic_WOMBATlite
     ! dts: Note, we use flux_virtual=.true. only to ensure that an stf array is allocated for dicp.
     ! The dicp stf is set to equal the dic stf in update_from_coupler.
     !-----------------------------------------------------------------------
-    call g_tracer_add(tracer_list, package_name, &
-        name = 'dicp', &
-        longname = 'preformed Dissolved Inorganic Carbon', &
-        units = 'mol/kg', &
-        prog = .true., &
-        flux_virtual = .true.)
+    if (do_tracer_dicp) then
+      call g_tracer_add(tracer_list, package_name, &
+          name = 'dicp', &
+          longname = 'preformed Dissolved Inorganic Carbon', &
+          units = 'mol/kg', &
+          prog = .true., &
+          flux_virtual = .true.)
+    endif
 
     ! DICr (remineralised dissolved inorganic carbon)
     !-----------------------------------------------------------------------
-    call g_tracer_add(tracer_list, package_name, &
-        name = 'dicr', &
-        longname = 'remineralised Dissolved Inorganic Carbon', &
-        units = 'mol/kg', &
-        prog = .true., &
-        flux_bottom = .true.)
+    if (do_tracer_dicr) then
+      call g_tracer_add(tracer_list, package_name, &
+          name = 'dicr', &
+          longname = 'remineralised Dissolved Inorganic Carbon', &
+          units = 'mol/kg', &
+          prog = .true., &
+          flux_bottom = .true.)
+    endif
 
     ! Alk (Total carbonate alkalinity)
     !-----------------------------------------------------------------------
@@ -1749,8 +1775,10 @@ module generic_WOMBATlite
     wombat%alk_vstf(:,:) = (wombat%alk_global / wombat%sal_global) * salt_flux_added(:,:) ! [mol/m2/s]
     wombat%p_alk_stf(:,:) = wombat%p_alk_stf(:,:) + wombat%alk_vstf(:,:) ! [mol/m2/s]
 
-    ! Set dicp stf equal to dic stf
-    call g_tracer_set_values(tracer_list, 'dicp', 'stf', wombat%p_dic_stf, isd, jsd)
+    if (do_tracer_dicp) then
+      ! Set dicp stf equal to dic stf
+      call g_tracer_set_values(tracer_list, 'dicp', 'stf', wombat%p_dic_stf, isd, jsd)
+    endif
 
   end subroutine generic_WOMBATlite_update_from_coupler
 
@@ -1964,7 +1992,7 @@ module generic_WOMBATlite
     real                                    :: phy_Fe2C, zoo_Fe2C, det_Fe2C
     real                                    :: phy_minqfe, phy_maxqfe
     real                                    :: zoo_slmor
-    real                                    :: hco3
+    real                                    :: hco3, ddic
     real                                    :: dzt_bot, dzt_bot_os
     real, dimension(:,:,:,:), allocatable   :: n_pools, c_pools
     logical                                 :: used
@@ -2254,8 +2282,8 @@ module generic_WOMBATlite
     call g_tracer_get_pointer(tracer_list, 'caco3', 'field', wombat%p_caco3) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'fe', 'field', wombat%p_fe) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'dic', 'field', wombat%p_dic) ! [mol/kg]
-    call g_tracer_get_pointer(tracer_list, 'dicr', 'field', wombat%p_dicr) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'alk', 'field', wombat%p_alk) ! [mol/kg]
+    if (do_tracer_dicr) call g_tracer_get_pointer(tracer_list, 'dicr', 'field', wombat%p_dicr) ! [mol/kg]
 
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
@@ -2980,33 +3008,19 @@ module generic_WOMBATlite
 
       ! Equation for DIC ! [molC/kg]
       !-----------------------------------------------------------------------
-      wombat%p_dic(i,j,k,tau) = wombat%p_dic(i,j,k,tau) + dtsb * ( &
-                              wombat%detremi(i,j,k) + &
-                              wombat%zoomorl(i,j,k) + &
-                              wombat%zooexcrphy(i,j,k) + &
-                              wombat%zooexcrdet(i,j,k) + &
-                              wombat%phymorl(i,j,k) - &
-                              wombat%phygrow(i,j,k) - &
-                              wombat%zoograzphy(i,j,k) * (1.0-wombat%fgutdiss) * wombat%pic2poc(i,j,k) - &
-                              wombat%phymorq(i,j,k) * wombat%pic2poc(i,j,k) - &
-                              wombat%zoomorq(i,j,k) * wombat%pic2poc(i,j,k) + &
-                              wombat%zoodiss(i,j,k) + wombat%caldiss(i,j,k) + &
-                              wombat%aradiss(i,j,k) + wombat%pocdiss(i,j,k) )
+      ddic = wombat%detremi(i,j,k) + wombat%zoomorl(i,j,k) + &
+          wombat%zooexcrphy(i,j,k) + wombat%zooexcrdet(i,j,k) + &
+          wombat%phymorl(i,j,k) - wombat%phygrow(i,j,k) - &
+          wombat%zoograzphy(i,j,k) * (1.0-wombat%fgutdiss) * wombat%pic2poc(i,j,k) - &
+          wombat%phymorq(i,j,k) * wombat%pic2poc(i,j,k) - &
+          wombat%zoomorq(i,j,k) * wombat%pic2poc(i,j,k) + &
+          wombat%zoodiss(i,j,k) + wombat%caldiss(i,j,k) + &
+          wombat%aradiss(i,j,k) + wombat%pocdiss(i,j,k)
+      wombat%p_dic(i,j,k,tau) = wombat%p_dic(i,j,k,tau) + dtsb * ddic
 
       ! Equation for DICr ! [molC/kg]
       !-----------------------------------------------------------------------
-      wombat%p_dicr(i,j,k,tau) = wombat%p_dicr(i,j,k,tau) + dtsb * ( &
-                               wombat%detremi(i,j,k) + &
-                               wombat%zoomorl(i,j,k) + &
-                               wombat%zooexcrphy(i,j,k) + &
-                               wombat%zooexcrdet(i,j,k) + &
-                               wombat%phymorl(i,j,k) - &
-                               wombat%phygrow(i,j,k) - &
-                               wombat%zoograzphy(i,j,k) * (1.0-wombat%fgutdiss) * wombat%pic2poc(i,j,k) - &
-                               wombat%phymorq(i,j,k) * wombat%pic2poc(i,j,k) - &
-                               wombat%zoomorq(i,j,k) * wombat%pic2poc(i,j,k) + &
-                               wombat%zoodiss(i,j,k) + wombat%caldiss(i,j,k) + &
-                               wombat%aradiss(i,j,k) + wombat%pocdiss(i,j,k) )
+      if (do_tracer_dicr) wombat%p_dicr(i,j,k,tau) = wombat%p_dicr(i,j,k,tau) + dtsb * ddic
 
       ! Equation for ALK ! [molC/kg]
       !-----------------------------------------------------------------------
@@ -3294,9 +3308,9 @@ module generic_WOMBATlite
       wombat%b_no3(i,j) = -16./122. * wombat%det_sed_remin(i,j) ! [mol/m2/s]
       wombat%b_o2(i,j) = -172./16. * wombat%b_no3(i,j) ! [mol/m2/s]
       wombat%b_dic(i,j) = 122./16. * wombat%b_no3(i,j) - wombat%caco3_sed_remin(i,j) ! [mol/m2/s]
-      wombat%b_dicr(i,j) = wombat%b_dic(i,j) ! [mol/m2/s]
       wombat%b_fe(i,j) = -1.0 * wombat%detfe_sed_remin(i,j) ! [mol/m2/s]
       wombat%b_alk(i,j) = -2.0 * wombat%caco3_sed_remin(i,j) - wombat%b_no3(i,j) ! [mol/m2/s]
+      if (do_tracer_dicr) wombat%b_dicr(i,j) = wombat%b_dic(i,j) ! [mol/m2/s]
     enddo; enddo
 
 
@@ -3314,9 +3328,9 @@ module generic_WOMBATlite
     call g_tracer_set_values(tracer_list, 'no3', 'btf', wombat%b_no3, isd, jsd)
     call g_tracer_set_values(tracer_list, 'o2', 'btf', wombat%b_o2, isd, jsd)
     call g_tracer_set_values(tracer_list, 'dic', 'btf', wombat%b_dic, isd, jsd)
-    call g_tracer_set_values(tracer_list, 'dicr', 'btf', wombat%b_dicr, isd, jsd)
     call g_tracer_set_values(tracer_list, 'fe', 'btf', wombat%b_fe, isd, jsd)
     call g_tracer_set_values(tracer_list, 'alk', 'btf', wombat%b_alk, isd, jsd)
+    if (do_tracer_dicr) call g_tracer_set_values(tracer_list, 'dicr', 'btf', wombat%b_dicr, isd, jsd)
 
 
     !=======================================================================
@@ -3893,9 +3907,12 @@ module generic_WOMBATlite
     allocate(wombat%b_no3(isd:ied, jsd:jed)); wombat%b_no3(:,:)=0.0
     allocate(wombat%b_o2(isd:ied, jsd:jed)); wombat%b_o2(:,:)=0.0
     allocate(wombat%b_dic(isd:ied, jsd:jed)); wombat%b_dic(:,:)=0.0
-    allocate(wombat%b_dicr(isd:ied, jsd:jed)); wombat%b_dicr(:,:)=0.0
     allocate(wombat%b_fe(isd:ied, jsd:jed)); wombat%b_fe(:,:)=0.0
     allocate(wombat%b_alk(isd:ied, jsd:jed)); wombat%b_alk(:,:)=0.0
+    if (do_tracer_dicr) then
+        allocate(wombat%b_dicr(isd:ied, jsd:jed))
+        wombat%b_dicr(:,:)=0.0
+    endif
 
     allocate(wombat%radbio(isd:ied, jsd:jed, 1:nk)); wombat%radbio(:,:,:)=0.0
     allocate(wombat%radmid(isd:ied, jsd:jed, 1:nk)); wombat%radmid(:,:,:)=0.0
@@ -4008,9 +4025,9 @@ module generic_WOMBATlite
         wombat%b_no3, &
         wombat%b_o2, &
         wombat%b_dic, &
-        wombat%b_dicr, &
         wombat%b_fe, &
         wombat%b_alk)
+    if (do_tracer_dicr) deallocate(wombat%b_dicr)
 
     deallocate( &
         wombat%radbio, &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -148,8 +148,8 @@ module generic_WOMBATlite
   logical :: do_burial           = .false. ! permanently bury organics and CaCO3 in sediments?
   logical :: do_tracer_dicp      = .false.  ! enable preformed dissolved inorganic carbon tracer, dicp?
   logical :: do_tracer_dicr      = .false.  ! enable remineralised dissolved inorganic carbon tracer dicr?
-  logical :: do_check_n_conserve = .true.  ! check that the N fluxes balance in the ecosystem
-  logical :: do_check_c_conserve = .true.  ! check that the C fluxes balance in the ecosystem
+  logical :: do_check_n_conserve = .false. ! check that the N fluxes balance in the ecosystem
+  logical :: do_check_c_conserve = .false. ! check that the C fluxes balance in the ecosystem
 
   namelist /generic_wombatlite_nml/ co2_calc, do_caco3_dynamics, do_colloidal_shunt, do_two_ligands, &
                                     do_burial, do_check_n_conserve, do_check_c_conserve

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -3149,8 +3149,12 @@ module generic_WOMBATlite
         ! pjb: tune minimum dissolved iron concentration to detection limit...
         !       this is essential for ensuring dFe is replenished in upper ocean and actually
         !       looks to be the secret of PISCES ability to replicate dFe limitation in the right places
-        wombat%f_fe(i,j,k) = max(wombat%dfefloor * umol_m3_to_mol_kg, &
-                                 wombat%f_fe(i,j,k)) * grid_tmask(i,j,k)
+        ! Only do this where the ocean is > 200m deep to avoid truncating negative tracer concentrations
+        ! at river mouths
+        if (wombat%zw(i,j,k) > 200) then
+          wombat%f_fe(i,j,k) = max(wombat%dfefloor * umol_m3_to_mol_kg, &
+                                wombat%f_fe(i,j,k)) * grid_tmask(i,j,k)
+        endif
       enddo
     enddo; enddo
 

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1810,7 +1810,7 @@ module generic_WOMBATlite
       do i = isc, iec
         do j = jsc, jec
           orgflux = wombat%det_btm(i,j) / dt * 86400 * 1e3 ! mmol C m-2 day-1
-          wombat%fbury(i,j) = 0.013 + 0.53 * (orgflux / (7.0 + orgflux))**2.0  ! Eq. 3 Dunne et al. 2007
+          wombat%fbury(i,j) = max(0.0, 0.013 + 0.53 * (orgflux / (7.0 + orgflux))**2.0)  ! Eq. 3 Dunne et al. 2007
         enddo
       enddo
     endif
@@ -1937,12 +1937,13 @@ module generic_WOMBATlite
     real                                    :: rdtts ! 1 / dt
     real, dimension(nbands)                 :: sw_pen
     real                                    :: swpar
-    real                                    :: g_npz, g_peffect, wzphy, wzdet
+    real                                    :: g_npz, g_peffect, wzphy, wzdet, zooprey
     real                                    :: zooegesphyfe, zooegesdetfe
     real                                    :: zooassiphyfe, zooassidetfe
     real                                    :: zooexcrphyfe, zooexcrdetfe
-    real                                    :: biophy, biozoo, biodet, biono3, biofer, biocaco3
-    real                                    :: biophyfe, biophy1, zooprey
+    real                                    :: phy_p, phyfe_p, pchl_p, zoo_p, det_p
+    real                                    :: phy_mmolm3, zoo_mmolm3, det_mmolm3, no3_mmolm3
+    real                                    :: fe_umolm3, caco3_mmolm3, phyfe_mmolm3
     real                                    :: fbc, zval
     real                                    :: P_expl, k_loss, k_loss_zoodiss
     real, parameter                         :: epsi = 1.0e-30
@@ -2242,33 +2243,20 @@ module generic_WOMBATlite
     ! dts attn: we should probably update prognostic tracers via pointers to avoid
     ! having to allocate all these field arrays
     ! dts attn: do we really want/need to force these to be positive?
-    call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'phy', 'field', wombat%f_phy, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'pchl', 'field', wombat%f_pchl, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'phyfe', 'field', wombat%f_phyfe, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'zoo', 'field', wombat%f_zoo, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'zoofe', 'field', wombat%f_zoofe, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'det', 'field', wombat%f_det, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'detfe', 'field', wombat%f_detfe, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'o2', 'field', wombat%f_o2, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'caco3', 'field', wombat%f_caco3, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'fe', 'field', wombat%f_fe, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'phy', 'field', wombat%f_phy, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'pchl', 'field', wombat%f_pchl, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'phyfe', 'field', wombat%f_phyfe, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'zoo', 'field', wombat%f_zoo, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'zoofe', 'field', wombat%f_zoofe, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'det', 'field', wombat%f_det, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'detfe', 'field', wombat%f_detfe, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'o2', 'field', wombat%f_o2, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'caco3', 'field', wombat%f_caco3, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'fe', 'field', wombat%f_fe, isd, jsd, ntau=tau) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau) ! [mol/kg]
     call g_tracer_get_values(tracer_list, 'dicr', 'field', wombat%f_dicr, isd, jsd, ntau=tau) ! [mol/kg]
-    call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau, &
-        positive=.true.) ! [mol/kg]
+    call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau) ! [mol/kg]
 
 
     !-----------------------------------------------------------------------!
@@ -2335,9 +2323,9 @@ module generic_WOMBATlite
         ! chlorophyll concentration conversion from mol/kg --> mg/m3 for look-up table
         chl = wombat%f_pchl(i,j,k) * 12.0 / mmol_m3_to_mol_kg
         ! detritus concentration conversion from mol/kg --> mgN/m3 for look-up table
-        ndet = wombat%f_det(i,j,k) * 16.0/122.0 * 14.0 / mmol_m3_to_mol_kg
+        ndet = max(0.0, wombat%f_det(i,j,k)) * 16.0/122.0 * 14.0 / mmol_m3_to_mol_kg
         ! CaCO3 concentration conversion from mol/kg --> kg/m3 for look-up table
-        carb = wombat%f_caco3(i,j,k) / mmol_m3_to_mol_kg * 100.09 * 1e-3 * 1e-3 ! convert to kg/m3
+        carb = max(0.0, wombat%f_caco3(i,j,k)) / mmol_m3_to_mol_kg * 100.09 * 1e-3 * 1e-3 ! convert to kg/m3
 
         ! Attenuation coefficients given chlorophyll concentration
         zchl = max(0.05, min(10.0, chl) )
@@ -2434,19 +2422,39 @@ module generic_WOMBATlite
 
       do k = 1,nk; do j = jsc,jec; do i = isc,iec;
 
-      ! Initialise some values and ratios (put into nicer units than mol/kg)
-      biophy   = max(epsi, wombat%f_phy(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
-      biophy1  = max(epsi, wombat%f_phy(i,j,1) ) / mmol_m3_to_mol_kg  ![mmol/m3]
-      biophyfe = max(epsi, wombat%f_phyfe(i,j,k))/ mmol_m3_to_mol_kg  ![mmol/m3]
-      biozoo   = max(epsi, wombat%f_zoo(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
-      biodet   = max(epsi, wombat%f_det(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
-      biono3   = max(epsi, wombat%f_no3(i,j,k) ) / mmol_m3_to_mol_kg  ![mmol/m3]
-      biofer   = max(epsi, wombat%f_fe(i,j,k)  ) / umol_m3_to_mol_kg  ![umol/m3]
-      biocaco3 = max(epsi, wombat%f_caco3(i,j,k))/ mmol_m3_to_mol_kg  ![mmol/m3]
-      phy_chlc = max(epsi, wombat%f_pchl(i,j,k)) / max(epsi, wombat%f_phy(i,j,k))
-      phy_Fe2C = max(epsi, wombat%f_phyfe(i,j,k))/ max(epsi, wombat%f_phy(i,j,k))
-      zoo_Fe2C = max(epsi, wombat%f_zoofe(i,j,k))/ max(epsi, wombat%f_zoo(i,j,k))
-      det_Fe2C = max(epsi, wombat%f_detfe(i,j,k))/ max(epsi, wombat%f_det(i,j,k))
+      ! Initialise some floored values and ratios (put into nicer units than mol/kg)
+      ! Loss/source coefficients are calculated using the floored values but are applied to the
+      ! un-floored tracer values
+      phy_p = max(0.0, wombat%f_phy(i,j,k))
+      phyfe_p = max(0.0, wombat%f_phyfe(i,j,k))
+      pchl_p = max(0.0, wombat%f_pchl(i,j,k))
+      zoo_p = max(0.0, wombat%f_zoo(i,j,k))
+      det_p = max(0.0, wombat%f_det(i,j,k))
+      phy_mmolm3 = phy_p / mmol_m3_to_mol_kg ! [mmol/m3]
+      phyfe_mmolm3 = phyfe_p / mmol_m3_to_mol_kg ! [mmol/m3]
+      zoo_mmolm3 = zoo_p / mmol_m3_to_mol_kg ! [mmol/m3]
+      det_mmolm3 = det_p / mmol_m3_to_mol_kg ! [mmol/m3]
+      no3_mmolm3 = max(0.0, wombat%f_no3(i,j,k)) / mmol_m3_to_mol_kg ! [mmol/m3]
+      fe_umolm3 = max(0.0, wombat%f_fe(i,j,k)) / umol_m3_to_mol_kg ![umol/m3]
+      caco3_mmolm3 = max(0.0, wombat%f_caco3(i,j,k)) / mmol_m3_to_mol_kg ![mmol/m3]
+      ! Only calculate these ratios when the denominator is > 0.0, else 0.0
+      if (phy_p > 0.0) then
+        phy_chlc = pchl_p / phy_p
+        phy_Fe2C = phyfe_p / phy_p
+      else
+        phy_chlc = 0.0
+        phy_Fe2C = 0.0
+      endif
+      if (zoo_p > 0.0) then
+        zoo_Fe2C = max(0.0, wombat%f_zoofe(i,j,k)) / zoo_p
+      else
+        zoo_Fe2C = 0.0
+      endif
+      if (det_p > 0.0) then
+        det_Fe2C = max(0.0, wombat%f_detfe(i,j,k)) / det_p
+      else
+        det_Fe2C = 0.0
+      endif
 
 
       !-----------------------------------------------------------------------!
@@ -2460,16 +2468,15 @@ module generic_WOMBATlite
       ! 1. Allometric scaling of 0.37 (Wickman et al., 2024; Science)
       ! 2. Apply variable K to set limitation term
 
-      wombat%phy_kni(i,j,k) = wombat%phykn * max(0.1, max(0.0, (biophy-wombat%phybiot))**0.37)
-      wombat%phy_kfe(i,j,k) = wombat%phykf * max(0.1, max(0.0, (biophy-wombat%phybiot))**0.37)
+      wombat%phy_kni(i,j,k) = wombat%phykn * max(0.1, max(0.0, (phy_mmolm3-wombat%phybiot))**0.37)
+      wombat%phy_kfe(i,j,k) = wombat%phykf * max(0.1, max(0.0, (phy_mmolm3-wombat%phybiot))**0.37)
       ! Nitrogen limitation (currently Michaelis-Menten term)
-      wombat%phy_lnit(i,j,k) = biono3 / (biono3 + wombat%phy_kni(i,j,k) + epsi)
+      wombat%phy_lnit(i,j,k) = no3_mmolm3 / (no3_mmolm3 + wombat%phy_kni(i,j,k) + epsi)
       ! Iron limitation (Quota model, constants from Flynn & Hipkin 1999)
       phy_minqfe = 0.00167 / 55.85 * max(wombat%phyminqc, phy_chlc)*12 + &
                    1.21e-5 * 14.0 / 55.85 / 7.625 * 0.5 * 1.5 * wombat%phy_lnit(i,j,k) + &
                    1.15e-4 * 14.0 / 55.85 / 7.625 * 0.5 * wombat%phy_lnit(i,j,k)
       wombat%phy_lfer(i,j,k) = min(1.0, max(0.0, (phy_Fe2C - phy_minqfe) / wombat%phyoptqf ))
-
 
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
@@ -2515,7 +2522,7 @@ module generic_WOMBATlite
                              min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))
 
       if (wombat%f_no3(i,j,k) > epsi) then
-        wombat%phygrow(i,j,k) = wombat%phy_mu(i,j,k) * wombat%f_phy(i,j,k) ! [molC/kg/s]
+        wombat%phygrow(i,j,k) = wombat%phy_mu(i,j,k) * phy_p ! [molC/kg/s]
       else
         wombat%phygrow(i,j,k) = 0.0
       endif
@@ -2544,8 +2551,8 @@ module generic_WOMBATlite
       ! 3. Estimate the rate that chlorophyll is synthesized towards this optimal
       !    Rates of chlorophyll synthesis are not instantaneous, and take hours to days
       !    Here, we make chlorophyll synthesis respond on a timescale of phytauqc
-      wombat%pchl_mu(i,j,k) = wombat%phy_mu(i,j,k) * wombat%f_pchl(i,j,k) &
-                            + (theta_opt - phy_chlc) / wombat%phytauqc * wombat%f_phy(i,j,k)
+      wombat%pchl_mu(i,j,k) = wombat%phy_mu(i,j,k) * pchl_p &
+                            + max(0.0, theta_opt - phy_chlc) / wombat%phytauqc * phy_p
 
 
       !-----------------------------------------------------------------------!
@@ -2560,16 +2567,22 @@ module generic_WOMBATlite
       ! 2. Ensure that dFe uptake increases or decreases in response to cell quota
       ! 3. Iron uptake of phytoplankton (reduced 10-fold in darkness)
 
-      phy_maxqfe = biophy * wombat%phymaxqf  !mmol Fe / m3
-      wombat%phy_feupreg(i,j,k) = (4.0 - 4.5 * wombat%phy_lfer(i,j,k) / &
-                                  (wombat%phy_lfer(i,j,k) + 0.5) )
-      wombat%phy_fedoreg(i,j,k) = max(0.0, (1.0 - biophyfe/phy_maxqfe) / &
-                                  abs(1.05 - biophyfe/phy_maxqfe) )
-      wombat%phy_dfeupt(i,j,k) = (wombat%phy_mumax(i,j,k) * phy_maxqfe * &
-                                  max(0.01, wombat%phy_lpar(i,j,k))**0.5 * &
-                                  biofer / (biofer + wombat%phy_kfe(i,j,k)) * &
-                                  wombat%phy_feupreg(i,j,k) * &
-                                  wombat%phy_fedoreg(i,j,k)) * mmol_m3_to_mol_kg
+      if (wombat%f_phy(i,j,k) > epsi) then
+        phy_maxqfe = phy_mmolm3 * wombat%phymaxqf  !mmol Fe / m3
+        wombat%phy_feupreg(i,j,k) = (4.0 - 4.5 * wombat%phy_lfer(i,j,k) / &
+                                    (wombat%phy_lfer(i,j,k) + 0.5) )
+        wombat%phy_fedoreg(i,j,k) = max(0.0, (1.0 - phyfe_mmolm3/phy_maxqfe) / &
+                                    abs(1.05 - phyfe_mmolm3/phy_maxqfe) )
+        wombat%phy_dfeupt(i,j,k) = (wombat%phy_mumax(i,j,k) * phy_maxqfe * &
+                                    max(0.01, wombat%phy_lpar(i,j,k))**0.5 * &
+                                    fe_umolm3 / (fe_umolm3 + wombat%phy_kfe(i,j,k)) * &
+                                    wombat%phy_feupreg(i,j,k) * &
+                                    wombat%phy_fedoreg(i,j,k)) * mmol_m3_to_mol_kg
+      else
+        wombat%phy_feupreg(i,j,k) = 0.0
+        wombat%phy_fedoreg(i,j,k) = 0.0
+        wombat%phy_dfeupt(i,j,k) = 0.0
+      endif
 
 
       !-----------------------------------------------------------------------!
@@ -2602,7 +2615,7 @@ module generic_WOMBATlite
       ! Colloidal dFe is considered to be whatever exceeds the inorganic solubility
       ! ceiling, although there is always a hard lower limit of 10% of total dFe.
       if (do_colloidal_shunt) then
-        wombat%fecol(i,j,k) = max(0.1 * biofer, biofer - fe3sol)
+        wombat%fecol(i,j,k) = max(0.1 * fe_umolm3, fe_umolm3 - fe3sol)
       else
         wombat%fecol(i,j,k) = 0.0
       endif
@@ -2615,7 +2628,7 @@ module generic_WOMBATlite
       ! a 0.7 log10 unit decrease in K in high light. The pH and DOC dependency (3rd term)
       ! comes from Ye et al. (2020) and increases binding strength at lower pH and higher
       ! concentrations of DOC.
-      fe_sfe = max(0.0, biofer - wombat%fecol(i,j,k))
+      fe_sfe = max(0.0, fe_umolm3 - wombat%fecol(i,j,k))
       biodoc = 40.0 + (1.0 - min(wombat%phy_lnit(i,j,k), wombat%phy_lfer(i,j,k))) * 40.0 ! proxy of DOC (mmol/m3)
       wombat%ligK(i,j,k) = 1e-9 * ( 10.0**( (17.27 - 1565.7 * I_ztemk ) &
                                   - 0.7 * wombat%radbio(i,j,k) / (wombat%radbio(i,j,k) + 10.0) ) &
@@ -2654,21 +2667,21 @@ module generic_WOMBATlite
       wombat%feprecip(i,j,k) = max(0.0, ( wombat%feIII(i,j,k) - fe3sol ) ) * wombat%knano_dfe
 
       ! Scavenging of Fe` onto biogenic particles
-      partic = (biodet*2 + biocaco3*8.3)
+      partic = (det_mmolm3*2 + caco3_mmolm3*8.3)
       wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (1e-7 + wombat%kscav_dfe * partic)
-      wombat%fescadet(i,j,k) = wombat%fescaven(i,j,k) * biodet*2 / (partic+epsi)
+      wombat%fescadet(i,j,k) = wombat%fescaven(i,j,k) * det_mmolm3*2 / (partic+epsi)
 
       ! Coagulation of colloidal Fe (umol/m3) to form sinking particles (mmol/m3)
       ! Following Tagliabue et al. (2023), make coagulation rate dependent on DOC and Phytoplankton biomass
-      biof = max(1/3., biophy / (biophy + 0.03))
+      biof = max(1/3., phy_mmolm3 / (phy_mmolm3 + 0.03))
       if (wombat%zw(i,j,k)<=hblt_depth(i,j)) then
-        zval = (      (12.*biof*biodoc + 9.05*biodet) &
-                + 2.49*biodet + 127.8*biof*biodoc + 725.7*biodet &
+        zval = (      (12.*biof*biodoc + 9.05*det_mmolm3) &
+                + 2.49*det_mmolm3 + 127.8*biof*biodoc + 725.7*det_mmolm3 &
                 + wombat%kagg_col * wombat%fecol(i,j,k)**4 / (wombat%fecol(i,j,k)**4 + wombat%kagg_kcol**4) &
                )*wombat%kcoag_dfe
       else
-        zval = ( 0.01 * (12.*biof*biodoc + 9.05*biodet) &
-                + 2.49*biodet + 127.8*biof*biodoc + 725.7*biodet &
+        zval = ( 0.01 * (12.*biof*biodoc + 9.05*det_mmolm3) &
+                + 2.49*det_mmolm3 + 127.8*biof*biodoc + 725.7*det_mmolm3 &
                 + wombat%kagg_col * wombat%fecol(i,j,k)**4 / (wombat%fecol(i,j,k)**4 + wombat%kagg_kcol**4) &
                )*wombat%kcoag_dfe
       endif
@@ -2696,16 +2709,16 @@ module generic_WOMBATlite
       ! NOTE: wombat%phymorq, wombat%zoomorq and wombat%detremi are now handled semi-implicitly
       ! and are calculated in Step 12
 
-      if (biophy>1e-3) then
-        wombat%phymorl(i,j,k) = wombat%phylmor * fbc * wombat%f_phy(i,j,k) ! [molC/kg/s]
+      if (phy_mmolm3 > 1e-3) then
+        wombat%phymorl(i,j,k) = wombat%phylmor * fbc * phy_p ! [molC/kg/s]
       else
         wombat%phymorl(i,j,k) = 0.0
       endif
 
-      if (biozoo>1e-3) then
+      if (zoo_mmolm3 > 1e-3) then
         ! reduce linear mortality (respiration losses) of zooplankton when there is low biomass
-        zoo_slmor = biozoo / (biozoo + wombat%zookz)
-        wombat%zoomorl(i,j,k) = wombat%zoolmor * fbc * wombat%f_zoo(i,j,k) * zoo_slmor ! [molC/kg/s]
+        zoo_slmor = zoo_mmolm3 / (zoo_mmolm3 + wombat%zookz)
+        wombat%zoomorl(i,j,k) = wombat%zoolmor * fbc * zoo_p * zoo_slmor ! [molC/kg/s]
       else
         wombat%zoomorl(i,j,k) = 0.0
       endif
@@ -2731,12 +2744,12 @@ module generic_WOMBATlite
       !   - add a switching component designed to weight the diet towards abundant prey
       !   - see their Eq. 19
       ! Emulates empirical basis of selective feeding on more abundant prey (Kiorboe et al., 2017; L&O)
-      wzphy = (wombat%zooprefphy(i,j,k) * biophy)**wombat%zoopreyswitch
-      wzdet = (wombat%zooprefdet(i,j,k) * biodet)**wombat%zoopreyswitch
+      wzphy = (wombat%zooprefphy(i,j,k) * phy_mmolm3)**wombat%zoopreyswitch
+      wzdet = (wombat%zooprefdet(i,j,k) * det_mmolm3)**wombat%zoopreyswitch
       wombat%zooprefphy(i,j,k) = wzphy / (wzphy + wzdet + epsi)
       wombat%zooprefdet(i,j,k) = wzdet / (wzphy + wzdet + epsi)
       ! Determine prey biomass after dynamic dietary fractions found
-      zooprey = (wombat%zooprefphy(i,j,k) * biophy + wombat%zooprefdet(i,j,k) * biodet)
+      zooprey = (wombat%zooprefphy(i,j,k) * phy_mmolm3 + wombat%zooprefdet(i,j,k) * det_mmolm3)
 
       ! Epsilon (prey capture rate coefficient) is made a function of phytoplankton
       ! biomass (Fig 2 of Rohr et al., 2024; GRL)
@@ -2752,8 +2765,8 @@ module generic_WOMBATlite
       !  1. zooplankton ingest C and Fe (the rest is egested)
       !  2. zooplankton assimilate the ingested C and Fe (the rest is excreted)
       if (zooprey>1e-3) then
-        wombat%zoograzphy(i,j,k) = g_npz * wombat%f_zoo(i,j,k) * (wombat%zooprefphy(i,j,k)*biophy)/zooprey ! [molC/kg/s]
-        wombat%zoograzdet(i,j,k) = g_npz * wombat%f_zoo(i,j,k) * (wombat%zooprefdet(i,j,k)*biodet)/zooprey ! [molC/kg/s]
+        wombat%zoograzphy(i,j,k) = g_npz * zoo_p * (wombat%zooprefphy(i,j,k) * phy_mmolm3) / zooprey ! [molC/kg/s]
+        wombat%zoograzdet(i,j,k) = g_npz * zoo_p * (wombat%zooprefdet(i,j,k) * det_mmolm3) / zooprey ! [molC/kg/s]
       else
         wombat%zoograzphy(i,j,k) = 0.0
         wombat%zoograzdet(i,j,k) = 0.0
@@ -2798,7 +2811,7 @@ module generic_WOMBATlite
         !  we account for the dissolution due to zooplankton grazing on particulates
         wombat%dissratcal(i,j,k) = (wombat%disscal * max(0.0, 1.0 - wombat%omega_cal(i,j,k))**2.2)
         wombat%dissratara(i,j,k) = (wombat%dissara * max(0.0, 1.0 - wombat%omega_ara(i,j,k))**1.5)
-        wombat%dissratpoc(i,j,k) = (wombat%dissdet * wombat%reminr(i,j,k) * biodet**2.0)
+        wombat%dissratpoc(i,j,k) = (wombat%dissdet * wombat%reminr(i,j,k) * det_mmolm3**2.0)
       else
         wombat%pic2poc(i,j,k) = wombat%f_inorg + 0.025
         wombat%dissratcal(i,j,k) = wombat%caco3lrem
@@ -2822,7 +2835,7 @@ module generic_WOMBATlite
       P_expl = wombat%phygrow(i,j,k) - &
                 wombat%phymorl(i,j,k) - &
                 wombat%zoograzphy(i,j,k)
-      if (biophy>1e-3) then
+      if (phy_mmolm3 > 1e-3) then
         ! Treat phymorq semi-implicitly
         k_loss = wombat%phyqmor / mmol_m3_to_mol_kg * wombat%f_phy(i,j,k)
         wombat%f_phy(i,j,k) = (wombat%f_phy(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
@@ -2860,7 +2873,7 @@ module generic_WOMBATlite
       P_expl = wombat%zooassiphy(i,j,k) + &
                 wombat%zooassidet(i,j,k) - &
                 wombat%zoomorl(i,j,k)
-      if (biozoo>1e-3) then
+      if (zoo_mmolm3 > 1e-3) then
         ! Treat zoomorq semi-implicitly
         k_loss = wombat%zooqmor / mmol_m3_to_mol_kg * wombat%f_zoo(i,j,k)
         wombat%f_zoo(i,j,k) = (wombat%f_zoo(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
@@ -2949,7 +2962,7 @@ module generic_WOMBATlite
                 wombat%zoograzphy(i,j,k) * (1. - wombat%fgutdiss) * wombat%pic2poc(i,j,k)
       if (wombat%f_caco3(i,j,k) > epsi) then
           ! Treat loss terms that are proportional to CaCO3 concentration implicitly
-          k_loss_zoodiss = wombat%zoograzdet(i,j,k) * wombat%fgutdiss / (biodet * mmol_m3_to_mol_kg)
+          k_loss_zoodiss = wombat%zoograzdet(i,j,k) * wombat%fgutdiss / max(epsi, det_p)
           k_loss = wombat%dissratcal(i,j,k) + wombat%dissratara(i,j,k) + wombat%dissratpoc(i,j,k) &
                         + k_loss_zoodiss
           wombat%f_caco3(i,j,k) = (wombat%f_caco3(i,j,k) + dtsb * P_expl) / (1.0 + dtsb * k_loss)
@@ -3177,11 +3190,12 @@ module generic_WOMBATlite
     ! crossing within a timestep
     do j = jsc,jec; do i = isc,iec;
       if (grid_kmt(i,j)>0) then
-        biophy1  = max(epsi, wombat%f_phy(i,j,1) ) / mmol_m3_to_mol_kg  ![mmol/m3]
-        wsink(:) = wombat%wdetbio * max(0.0, biophy1 - wombat%phybiot)**(0.21)
+        phy_mmolm3  = wombat%f_phy(i,j,1) / mmol_m3_to_mol_kg ! [mmol/m3]
+        wsink(:) = wombat%wdetbio * max(0.0, phy_mmolm3 - wombat%phybiot)**(0.21)
         do k=1,nk
           wsink(k) = wsink(k) + 10.0/86400.0 * min(1.0, &
-                     (wombat%f_caco3(i,j,k) / (wombat%f_det(i,j,k) + wombat%f_caco3(i,j,k) + epsi)))
+                     (max(0.0, wombat%f_caco3(i,j,k)) / &
+                     (max(0.0, wombat%f_det(i,j,k)) + max(0.0, wombat%f_caco3(i,j,k)) + epsi)))
           ! Increase sinking rate with depth to achieve power law behaviour
           wsink(k) = wsink(k) + max(0.0, wombat%zw(i,j,k)/5000.0 * (wombat%wdetmax - wsink(k)))
           ! CaCO3 sinks slower than general detritus because it tends to be smaller

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -213,10 +213,6 @@ module generic_WOMBATlite
         alk_global, &
         no3_global, &
         sio2_surf, &
-        dic_min, &
-        dic_max, &
-        alk_min, &
-        alk_max, &
         htotal_scale_lo, &
         htotal_scale_hi, &
         htotal_in, &
@@ -1175,22 +1171,6 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------
     call g_tracer_add_param('htotal_scale_hi', wombat%htotal_scale_hi, 100.0)
 
-    ! Absolute minimum of dissolved inorganic carbon [mmol/m3] for co2 sys calcs
-    !-----------------------------------------------------------------------
-    call g_tracer_add_param('dic_min', wombat%dic_min, 500.0)
-
-    ! Absolute maximum of dissolved inorganic carbon [mmol/m3] for co2 sys calcs
-    !-----------------------------------------------------------------------
-    call g_tracer_add_param('dic_max', wombat%dic_max, 3000.0)
-
-    ! Absolute minimum of alkalinity [mmol/m3] for co2 sys calcs
-    !-----------------------------------------------------------------------
-    call g_tracer_add_param('alk_min', wombat%alk_min, 500.0)
-
-    ! Absolute maximum of alkalinity [mmol/m3] for co2 sys calcs
-    !-----------------------------------------------------------------------
-    call g_tracer_add_param('alk_max', wombat%alk_max, 3000.0)
-
     ! Global average surface concentration of inorganic silicate [mol/kg]
     !-----------------------------------------------------------------------
     call g_tracer_add_param('sio2_surf', wombat%sio2_surf, 35.0e-3 / 1035.0)
@@ -2129,10 +2109,10 @@ module generic_WOMBATlite
      if (k==1) then !{
        call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
            Temp(:,:,k), Salt(:,:,k), &
-           min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_dic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
+           wombat%f_dic(:,:,k), &
            max(wombat%f_no3(:,:,k) / 16., 1e-9), &
            wombat%sio2(:,:), &
-           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
+           wombat%f_alk(:,:,k), &
            wombat%htotallo(:,:), wombat%htotalhi(:,:), &
            wombat%htotal(:,:,k), &
            co2_calc=trim(co2_calc), &
@@ -2149,10 +2129,10 @@ module generic_WOMBATlite
 
        call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
            Temp(:,:,k), Salt(:,:,k), &
-           min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_dic(:,:,k), wombat%dic_min*mmol_m3_to_mol_kg)), &
+           wombat%f_dic(:,:,k), &
            max(wombat%f_no3(:,:,k) / 16., 1e-9), &
            wombat%sio2(:,:), &
-           min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,k), wombat%alk_min*mmol_m3_to_mol_kg)), &
+           wombat%f_alk(:,:,k), &
            wombat%htotallo(:,:), wombat%htotalhi(:,:), &
            wombat%htotal(:,:,k), &
            co2_calc=trim(co2_calc), zt=wombat%zw(:,:,k), &
@@ -3287,10 +3267,10 @@ module generic_WOMBATlite
 
     call FMS_ocmip2_co2calc(CO2_dope_vec, wombat%sedmask(:,:), &
         wombat%sedtemp(:,:), wombat%sedsalt(:,:), &
-        min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%seddic(:,:), wombat%dic_min*mmol_m3_to_mol_kg)), &
+        wombat%seddic(:,:), &
         max(wombat%sedno3(:,:) / 16., 1e-9), &
         wombat%sio2(:,:), & ! dts: This is currently constant, equal to wombat%sio2_surf
-        min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%sedalk(:,:), wombat%alk_min*mmol_m3_to_mol_kg)), &
+        wombat%sedalk(:,:), &
         wombat%sedhtotal(:,:)*wombat%htotal_scale_lo, &
         wombat%sedhtotal(:,:)*wombat%htotal_scale_hi, &
         wombat%sedhtotal(:,:), &
@@ -3748,10 +3728,10 @@ module generic_WOMBATlite
 
       call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,1), &
           SST(:,:), SSS(:,:), &
-          min(wombat%dic_max*mmol_m3_to_mol_kg, max(wombat%f_dic(:,:,1), wombat%dic_min*mmol_m3_to_mol_kg)), &
+          wombat%f_dic(:,:,1), &
           max(wombat%f_no3(:,:,1) / 16., 1e-9), &
           wombat%sio2(:,:), &
-          min(wombat%alk_max*mmol_m3_to_mol_kg, max(wombat%f_alk(:,:,1), wombat%alk_min*mmol_m3_to_mol_kg)), &
+          wombat%f_alk(:,:,1), &
           wombat%htotallo(:,:), wombat%htotalhi(:,:), &
           wombat%htotal(:,:,1), &
           co2_calc=trim(co2_calc), &

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -3191,7 +3191,12 @@ contains
 
           ! Sinking of tracer into a sediment reservoir?
           if (_ALLOCATED(g_tracer%btm_reservoir)) then
-             sink(nz+1) = sink_dist(nz) !PJB [13th Nov 2024] to allow sinking into bottom reservoir
+             ! Don't sink negative tracers into sediment
+             if (g_tracer%field(i,j,nz,tau) <= 0.0) then
+               sink(nz+1) = 0.0
+             else
+               sink(nz+1) = sink_dist(nz) !PJB [13th Nov 2024] to allow sinking into bottom reservoir
+             endif
           else
              sink(nz+1) = 0.0 
           endif
@@ -3209,14 +3214,15 @@ contains
                 sink(k) = sink_dist(k)
                 h_minus_dsink(k) = (h_old(i,j,k) + sink(k+1)) - sink(k)
              endif
+
+             ! Don't sink negative tracers
+             if (g_tracer%field(i,j,k-1,tau) <= 0.0) then
+               h_minus_dsink(k) = h_minus_dsink(k) + sink(k)
+               sink(k) = 0.0
+             endif
           enddo
 
           sink(1) = 0.0 ; h_minus_dsink(1) = (h_old(i,j,1) + sink(2))
-
-          !Avoid sinking tracers with negative concentrations
-          do k=2,nz+1
-             if(g_tracer%field(i,j,k-1,tau) <= 0.0) sink(k) = 0.0
-          enddo
 
           ! Now solve the tridiagonal equation for the tracer concentrations.
 


### PR DESCRIPTION
The main change in this PR is to remove the zero-floors (`positive=.true.`) on WOMBAT tracers at the beginning of the `update_from_source` routine. The zero-floors act as an artificial tracer source, breaking conservation, and can contribute to instabilities under certain circumstances (e.g. at river outflows, see here https://github.com/ACCESS-NRI/access-om2-configs/issues/298). With the changes in this PR, tracer concentrations can now go negative. The terms on the RHS of the tendency equations are calculated using floored tracer values where appropriate and do not go negative (I have tested this in a 2 month OM2 0.1deg run). As part of this change, I also moved to using pointers for the prognostic tracer arrays to avoid unnecessary allocation/copies.

In addition to removing the zero-floors, this PR also fixes a bug in the `generic_tracer_utils::g_tracer_vertdiff_G` routine. While the routine claimed not to sink negative tracers, the implementation was not correct, leading to extreme negative values under certain circumstances (again see here https://github.com/ACCESS-NRI/access-om2-configs/issues/298).

Finally, three additional small changes are included:
- The parameters `dic_min`, `dic_max`, `alk_min`, `alk_max` are removed
- Inclusion of prognostic tracers `dicp` and `dicr` can now be controlled with namelist parameters `do_tracer_dicp` and `do_tracer_dicr`
- Namelist parameters `do_check_n_conserve` and `do_check_c_conserve` are now `.false.` by default

Still to do:
- [x] Update the docs accordingly