### PR TITLE
Wombatlite low o2conditions

### DIFF
--- a/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
+++ b/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
@@ -913,11 +913,11 @@ since hydrolyzation of organic detritus is performed by an heterotrophic bacteri
 
 ### 10. Zooplankton grazing, egestion, excretion and assimilation.
 
-**Grazing by zooplankton** (`g_npz`, $g_{zoo}$, [s<sup>-1</sup>]) is computed using a Holling Type III functional response [Holling, 1959](https://doi.org/10.4039/Ent91385-7):
+**Grazing by zooplankton** (`g_zoo`, $g_{zoo}$, [s<sup>-1</sup>]) is computed using a Holling Type III functional response [Holling, 1959](https://doi.org/10.4039/Ent91385-7):
 
 $$
 \begin{align}
-g_{zoo} =& \quad \dfrac{\mu_{zoo}^{max} \left(β_{hete}\right)^{T} \varepsilon \left(B_{prey}^{C}\right)^{2}}{\mu_{zoo}^{max} \left(β_{hete}\right)^{T} + \varepsilon \left(B_{prey}^{C}\right)^{2}}
+g_{zoo} =& \quad \dfrac{\mu_{zoo}^{max} \left(β_{hete}\right)^{T} \cdot L_{zoo}^{O_2} \varepsilon \left(B_{prey}^{C}\right)^{2}}{\mu_{zoo}^{max} \left(β_{hete}\right)^{T} + \varepsilon \left(B_{prey}^{C}\right)^{2}}
 \end{align}
 $$
 
@@ -925,8 +925,17 @@ _where_ <br>
 - $\mu_{zoo}^{max}$ is the maximum rate of zooplankton grazing at 0ºC (`zoogmax`, [s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature (`Temp(i,j,k)`, [ºC]) <br>
+- $L_{zoo}^{O_2}$ is a limiter of grazing in low oxygen conditions (`zoo_o2lim`, [dimensionless]) <br>
 - $B_{prey}^{C}$ is the concentration of prey biomass (`zooprey`, [mmol C m<sup>-3</sup>]) <br>
 - $\varepsilon$ is the prey capture rate coefficient (`zooeps(i,j,k)`, [(mmol C m<sup>-3</sup>)<sup>-2</sup>]) <br>
+
+We apply an oxygen limitation to grazing at low oxygen concentrations (`zoo_o2lim`, $L_{zoo}^{O_2}$, [dimensionless]) based on the review of [Medina et al. (2017)](https://doi.org/10.3389/fmars.2017.00105) who found that from 5 µM to undetectable concentrations of oxygen, protist consumption of a bacterial population decreased from 28% to 13% of the population. Although they still see some consumption at undetectable oxygen concentrations, we scale grazing down to zero at an oxygen concentration of zero to avoid unrealistic negative oxygen concentrationsdue to grazing at zero oxygen:
+
+$$
+\begin{align}
+L_{zoo}^{O_2} =& \quad \left(1 - e^{\left(-\dfrac{O_2}{10}\right)}\right)
+\end{align}
+$$
 
 Total grazing of biomass by zooplankton ([mol C kg<sup>-1</sup> day<sup>-1</sup>]) is therefore
 

--- a/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
+++ b/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
@@ -44,16 +44,18 @@ The following are the active tracers in WOMBAT-lite
 
 The following are logical statements within the `input.nml` namelist file that can be switched to TRUE or FALSE at runtime. 
 
-| Logical             | Description                                                                 | Default setting  |
-|---------------------|-----------------------------------------------------------------------------|------------------|
-| `do_caco3_dynamics`   | Production and dissolution of CaCO3 depends on carbon system state          | .true.           |
-| `do_colloidal_shunt`  | Fraction of dissolved iron is colloids that coagulate onto sinking material | .true.           |
-| `do_two_ligands`      | Complex soluble iron using two ligands (weak + strong) rather than one      | .false.          |
-| `do_burial`           | Permanently bury a fraction of sinking detrital material into the sediments | .false.          |
-| `do_tracer_dicp`      | Carry preformed dissolved inorganic carbon (dicp) as a tracer               | .false.          |
-| `do_tracer_dicr`      | Carry remineralised dissolved inorganic carbon (dicr) as a tracer           | .false.          |
-| `do_check_n_conserve` | Checks that the ecosystem calculations are conserving the mass of nitrogen  | .false.          |
-| `do_check_c_conserve` | Checks that the ecosystem calculations are conserving the mass of carbon    | .false.          |
+| Logical                        | Description                                                                     | Default setting  |
+|--------------------------------|---------------------------------------------------------------------------------|------------------|
+| `do_caco3_dynamics`            | Production and dissolution of CaCO3 depends on carbon system state              | .true.           |
+| `do_colloidal_shunt`           | Fraction of dissolved iron is colloids that coagulate onto sinking material     | .true.           |
+| `do_two_ligands`               | Complex soluble iron using two ligands (weak + strong) rather than one          | .false.          |
+| `do_burial`                    | Permanently bury a fraction of sinking detrital material into the sediments     | .true.           |
+| `do_nitrogen_fixation`         | Allow implicit nitrogen fixing popoulation to add NO<sub>3</sub> to ocean       | .true.           |
+| `do_benthic_denitrification`   | Allow implicit benthic bacterial population to remove NO<sub>3</sub> from ocean | .true.           |
+| `do_tracer_dicp`               | Carry preformed dissolved inorganic carbon (dicp) as a tracer                   | .false.          |
+| `do_tracer_dicr`               | Carry remineralised dissolved inorganic carbon (dicr) as a tracer               | .false.          |
+| `do_check_n_conserve`          | Checks that the ecosystem calculations are conserving the mass of nitrogen      | .false.          |
+| `do_check_c_conserve`          | Checks that the ecosystem calculations are conserving the mass of carbon        | .false.          |
 
 We note that when `do_two_ligands` is set to `.true.`, the `ligK` diagnostic variable reflects the binding strength of the strong ligand. However, when `do_two_ligands` is set to `.false.`, this diagnostic (`ligK`) reflects the binding strength of the bulk ligand pool.
 
@@ -66,41 +68,44 @@ The following are all **2D** diagnostic output variables from WOMBAT-lite.
 | Diagnostic        | Description                                                                                          | Units                                |
 | ----------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `pco2`            | Surface aqueous partial pressure of CO₂                                                              | µatm                                 |
-| `det_sed_remin`   | Rate of remineralisation of detritus in accumulated sediment                                         | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `det_sed_depst`   | Rate of deposition of detritus to sediment at base of water column                                   | mol m<sup>-2</sup> s<sup>-1</sup>    |
+| `det_sed_remin`   | Rate of remineralisation of detritus in accumulated sediment                                         | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `det_sed_depst`   | Rate of deposition of detritus to sediment at base of water column                                   | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `det_sed_denit`   | Rate of denitrification (NO<sub>3</sub> consumption) in accumulated sediment                         | mol N m<sup>-2</sup> s<sup>-1</sup>  |
 | `fbury`           | Fraction of deposited detritus permanently buried beneath sediment                                   | dimensionless                        |
-| `detfe_sed_remin` | Rate of remineralisation of detrital iron in accumulated sediment                                    | mol m<sup>-2</sup> s<sup>-1</sup>    |
+| `fdenit`          | Fraction of detritus remineralised via denitrification                                               | dimensionless                        |
+| `detfe_sed_remin` | Rate of remineralisation of detrital iron in accumulated sediment                                    | mol Fe m<sup>-2</sup> s<sup>-1</sup> |
 | `detfe_sed_depst` | Rate of deposition of detrital iron to sediment at base of water column                              | mol Fe m<sup>-2</sup> s<sup>-1</sup> |
-| `caco3_sed_remin` | Rate of remineralisation of CaCO₃ in accumulated sediment                                            | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `caco3_sed_depst` | Rate of deposition of CaCO₃ to sediment at base of water column                                      | mol m<sup>-2</sup> s<sup>-1</sup>    |
+| `caco3_sed_remin` | Rate of remineralisation of CaCO₃ in accumulated sediment                                            | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `caco3_sed_depst` | Rate of deposition of CaCO₃ to sediment at base of water column                                      | mol C m<sup>-2</sup> s<sup>-1</sup>  |
 | `zeuphot`         | Depth of the euphotic zone (1% incident light)                                                       | m                                    |
 | `seddep`          | Depth of the bottom layer                                                                            | m                                    |
 | `sedmask`         | Mask of active sediment points                                                                       | dimensionless                        |
 | `sedtemp`         | Temperature in the bottom layer                                                                      | °C                                   |
 | `sedsalt`         | Salinity in the bottom layer                                                                         | psu                                  |
-| `sedno3`          | Nitrate concentration in the bottom layer                                                            | mol kg<sup>-1</sup>                  |
-| `seddic`          | Dissolved inorganic carbon concentration in the bottom layer                                         | mol kg<sup>-1</sup>                  |
-| `sedalk`          | Alkalinity concentration in the bottom layer                                                         | mol kg<sup>-1</sup>                  |
-| `sedhtotal`       | H<sup>+</sup> ion concentration in the bottom layer                                                  | mol kg<sup>-1</sup>                  |
-| `sedco3`          | CO₃<sup>2−</sup> ion concentration in the bottom layer                                               | mol kg<sup>-1</sup>                  |
+| `sedno3`          | Nitrate concentration in the bottom layer                                                            | mol N kg<sup>-1</sup>                |
+| `sedo2`           | Dissolved oxygen concentration in the bottom layer                                                   | mol O2 kg<sup>-1</sup>               |
+| `seddic`          | Dissolved inorganic carbon concentration in the bottom layer                                         | mol C kg<sup>-1</sup>                |
+| `sedalk`          | Alkalinity concentration in the bottom layer                                                         | mol Eq kg<sup>-1</sup>               |
+| `sedhtotal`       | H<sup>+</sup> ion concentration in the bottom layer                                                  | mol H<sup>+</sup>kg<sup>-1</sup>     |
+| `sedco3`          | CO₃<sup>2−</sup> ion concentration in the bottom layer                                               | mol C kg<sup>-1</sup>                |
 | `sedomega_cal`    | Calcite saturation state in the bottom layer                                                         | dimensionless                        |
-| `o2_stf`          | Surface flux of dissolved oxygen into ocean                                                          | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `no3_stf`         | Surface flux of nitrate into ocean                                                                   | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `fe_stf`          | Surface flux of dissolved iron into ocean                                                            | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `det_stf`         | Surface flux of detritus into ocean                                                                  | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `dic_stf`         | Surface flux of dissolved inorganic carbon into ocean                                                | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `dicp_stf`        | Surface flux of preformed dissolved inorganic carbon into ocean                                      | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `alk_stf`         | Surface flux of alkalinity into ocean                                                                | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `no3_vstf`        | Virtual flux of nitrate into ocean due to salinity restoring/correction                              | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `dic_vstf`        | Virtual flux of dissolved inorganic carbon into ocean due to salinity restoring/correction           | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `dicp_vstf`       | Virtual flux of preformed dissolved inorganic carbon into ocean due to salinity restoring/correction | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `alk_vstf`        | Virtual flux of alkalinity into ocean due to salinity restoring/correction                           | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `o2_btf`          | Bottom flux of dissolved oxygen into ocean                                                           | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `no3_btf`         | Bottom flux of nitrate into ocean                                                                    | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `fe_btf`          | Bottom flux of dissolved iron into ocean                                                             | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `dic_btf`         | Bottom flux of dissolved inorganic carbon into ocean                                                 | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `dicr_btf`        | Bottom flux of preformed dissolved inorganic carbon into ocean                                       | mol m<sup>-2</sup> s<sup>-1</sup>    |
-| `alk_btf`         | Bottom flux of alkalinity into ocean                                                                 | mol m<sup>-2</sup> s<sup>-1</sup>    |
+| `o2_stf`          | Surface flux of dissolved oxygen into ocean                                                          | mol O2 m<sup>-2</sup> s<sup>-1</sup> |
+| `no3_stf`         | Surface flux of nitrate into ocean                                                                   | mol N m<sup>-2</sup> s<sup>-1</sup>  |
+| `fe_stf`          | Surface flux of dissolved iron into ocean                                                            | mol Fe m<sup>-2</sup> s<sup>-1</sup> |
+| `det_stf`         | Surface flux of detritus into ocean                                                                  | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `dic_stf`         | Surface flux of dissolved inorganic carbon into ocean                                                | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `dicp_stf`        | Surface flux of preformed dissolved inorganic carbon into ocean                                      | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `alk_stf`         | Surface flux of alkalinity into ocean                                                                | mol Eq m<sup>-2</sup> s<sup>-1</sup> |
+| `no3_vstf`        | Virtual flux of nitrate into ocean due to salinity restoring/correction                              | mol N m<sup>-2</sup> s<sup>-1</sup>  |
+| `dic_vstf`        | Virtual flux of dissolved inorganic carbon into ocean due to salinity restoring/correction           | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `dicp_vstf`       | Virtual flux of preformed dissolved inorganic carbon into ocean due to salinity restoring/correction | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `alk_vstf`        | Virtual flux of alkalinity into ocean due to salinity restoring/correction                           | mol Eq m<sup>-2</sup> s<sup>-1</sup> |
+| `o2_btf`          | Bottom flux of dissolved oxygen into ocean                                                           | mol O2 m<sup>-2</sup> s<sup>-1</sup> |
+| `no3_btf`         | Bottom flux of nitrate into ocean                                                                    | mol N m<sup>-2</sup> s<sup>-1</sup>  |
+| `fe_btf`          | Bottom flux of dissolved iron into ocean                                                             | mol Fe m<sup>-2</sup> s<sup>-1</sup> |
+| `dic_btf`         | Bottom flux of dissolved inorganic carbon into ocean                                                 | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `dicr_btf`        | Bottom flux of preformed dissolved inorganic carbon into ocean                                       | mol C m<sup>-2</sup> s<sup>-1</sup>  |
+| `alk_btf`         | Bottom flux of alkalinity into ocean                                                                 | mol Eq m<sup>-2</sup> s<sup>-1</sup> |
 
 
 The following are all **3D** diagnostic output variables from WOMBAT-lite.
@@ -127,6 +132,10 @@ The following are all **3D** diagnostic output variables from WOMBAT-lite.
 | `phy_lnit`    | Limitation of phytoplankton by nitrogen                                | dimensionless                                    |
 | `phy_lfer`    | Limitation of phytoplankton by iron                                    | dimensionless                                    |
 | `phy_dfeupt`  | Uptake of dFe by phytoplankton                                         | mol kg<sup>-1</sup> s<sup>-1</sup>               |
+| `tri_mumax`   | Maximum growth rate of trichodesmium                                   | s<sup>-1</sup>                                   |
+| `tri_lpar`    | Limitation of trichodesmium by light                                   | dimensionless                                    |
+| `tri_lfer`    | Limitation of trichodesmkum by iron                                    | dimensionless                                    |
+| `nitrfix`     | Implicit nitrogen fixation rate (NO<sub>3</sub> production)            | mol N kg<sup>-1</sup> s<sup>-1</sup>             |
 | `feIII`       | Free iron (Fe<sup>3+</sup>)                                            | mol kg<sup>-1</sup>                              |
 | `ligK`        | Ligand stability constant                                              | L mol<sup>-1</sup>                               |
 | `felig`       | Ligand-bound dissolved iron                                            | mol kg<sup>-1</sup>                              |
@@ -186,11 +195,12 @@ The subroutine `generic_WOMBATlite_update_from_source` is the heart of the World
 9. Mortality and remineralisation.
 10. Zooplankton grazing, growth, excretion and egestion.
 11. CaCO3 calculations.
-12. Tracer tendencies (update tracer concentrations).
-13. Check for conservation of mass.
-14. Additional operations on tracers.
-15. Sinking rate of particulates.
-16. Sedimentary processes.
+12. Implicit nitrogen fixation
+13. Tracer tendencies (update tracer concentrations).
+14. Check for conservation of mass.
+15. Additional operations on tracers.
+16. Sinking rate of particulates.
+17. Sedimentary processes.
 
 Below is a step‑by‑step explanation of each section together with the key equations. Variable names in grey follow the Fortran code, while variable names in math font are pointers to the equations; i,j,k refer to horizontal and vertical indices; square brackets denote units. If a variable is without i,j,k dimensions, this variable is held as a scalar and not an array.
 
@@ -200,9 +210,9 @@ The model carries tracers in [mol kg<sup>-1</sup>]. That is, moles of solute/tra
 
 ### Parameter set and default values
 
-| Parameter        | Description                                                                 | Value              |
-|------------------|-----------------------------------------------------------------------------|--------------------|
-| `alphabio`         | Phytoplankton initial slope of P–I curve [(W/m²)⁻¹ (mg/mg)⁻¹ s⁻¹]           | 3.0                |
+| Parameter          | Description                                                                 | Value              |
+|--------------------|-----------------------------------------------------------------------------|--------------------|
+| `alphabio`         | Phytoplankton initial slope of P–I curve [(W/m²)⁻¹ (mg/mg)⁻¹]               | 3.0                |
 | `abioa`            | Autotrophy maximum growth rate parameter a [s⁻¹]                            | 1.0/86400.0        |
 | `bbioa`            | Autotrophy maximum growth rate parameter b [1]                              | 1.050              |
 | `bbioh`            | Heterotrophy maximum growth rate parameter b [1]                            | 1.060              |
@@ -216,6 +226,10 @@ The model carries tracers in [mol kg<sup>-1</sup>]. That is, moles of solute/tra
 | `phylmor`          | Phytoplankton linear mortality rate constant [s⁻¹]                          | 0.005/86400.0      |
 | `phyqmor`          | Phytoplankton quadratic mortality rate constant [(mmolC/m³)⁻¹ s⁻¹]          | 0.05/86400.0       |
 | `phybiot`          | Phytoplankton biomass threshold [mmolC/m³]                                  | 0.6                |
+| `alphabio_tri`     | Trichodesmium initial slope of P–I curve [(W/m²)⁻¹ (mg/mg)⁻¹]               | 1.8                |
+| `trikf`            | Trichodesmium half saturation constant for iron uptake [µmolFe/m³]          | 0.125              |
+| `trichlc`          | Trichodesmium chlorophyll to carbon ratio [mol C (mol C)<sup>-1</sup>]      | 0.01               |
+| `trin2c`           | Trichodesmium nitrogen to carbon ratio [molN (mol C)<sup>-1</sup>]          | 50/300             |
 | `zooCingest`       | Zooplankton ingestion efficiency of carbon [molC/molC]                      | 0.8                |
 | `zooCassim`        | Zooplankton assimilation efficiency of carbon [molC/molC]                   | 0.3                |
 | `zooFeingest`      | Zooplankton ingestion efficiency of iron [molFe/molFe]                      | 0.2                |
@@ -1202,7 +1216,55 @@ When $CaCO_3$ dynamics are disabled (`do_caco3_dynamics = .false.`), the model u
 ---
 
 
-### 12. Tracer tendencies.
+### 12. Implicit nitrogen fixation.
+
+Because we do not consider diazotrophs as an explicit phytoplankton functional type, we represent the fixation of nitrogen implicitly using a simple parameterization dependent on temperature, nutrient and light availability when `do_nitrogen_fixation == .true.`. The equation for new nitrogen (specifically NO<sub>3</sub>) added via diazotrophy is:
+
+$$
+\begin{align}
+\mu_{diazo}^{\rightarrow NO_3} =& \quad \mu_{diazo}^{max} \left(1 - L_{phy}^{N} \right) \\
+                                & \min\left(L_{diazo}^{Fe}, L_{diazo}^{PAR}\right) R_{diazo}^{N:C} \cdot 1 \times 10^{-6}
+\end{align}
+$$
+
+_where_ <br>
+- $\mu_{diazo}^{max}$ is the temperature-dependent maximum growth rate of diazotrophs (`tri_mumax(i,j,k)`, [s<sup>-1</sup>]) <br>
+- $L_{phy}^{N}$ is the limitation term of nano-phytoplankton growth on nitrogen (`phy_lnit(i,j,k)`, [dimensionless])  <br>
+- $L_{diazo}^{Fe}$ is the limitation term of diazotroph growth on iron (`tri_lfer(i,j,k)`, [dimensionless])  <br>
+- $L_{diazo}^{PAR}$ is the limitation term of diazotroph growth on light (`tri_lpar(i,j,k)`, [dimensionless])  <br>
+- $R_{diazo}^{N:C}$ is the ratio of N:C within diazotrophic biomass (`trin2c`, [mol N (mol C)<sup>-1</sup>]) <br>
+- $1 \times 10^{-6}$ is a conversion factor to mol kg<sup>-1</sup> <br>
+
+The temperature-dependent maximum growth rate ($\mu_{diazo}^{max}$) is taken directly from [Wrightson et al. (2022)]( https://doi.org/10.1111/gcb.16399) who based their formulation on the work of [Jiang et al. (2018)](https://doi.org/10.1038/s41558-018-021):
+
+$$
+\begin{align}
+\mu_{diazo}^{max} =& \quad \left( -0.000399(T)^{3} + 0.02685(T)^{2} - 0.555T + 3.633 \right) \dfrac{1}{86400}
+\end{align}
+$$
+
+_where_ <br>
+- $T$ is in situ water temperature (`Temp(i,j,k)`, [ºC]) and we only consider $T > 15.8$ºC <br>
+- $\dfrac{1}{86400}$ converts their formula from units of [day<sup>-1</sup>] to [s<sup>-1</sup>] <br>
+
+The iron and light limitation terms are as follows:
+
+$$
+\begin{align}
+L_{diazo}^{Fe} =& \quad \dfrac{dFe}{dFe + K_{diazo}^{Fe}} \\
+L_{diazo}^{PAR} =& \quad 1 - e^{- \alpha_{diazo} PAR}
+\end{align}
+$$
+
+_where_ <br>
+- $dFe$ is the in situ concentration of dissolved iron (`fe_umolm3`, [nmol Fe kg<sup>-1</sup>]) <br>
+- $K_{diazo}^{Fe}$ is the half-saturation coefficient for uptake of dissolved iron by diazotrophs (`trikf`, [nmol Fe kg<sup>-1</sup>]) <br>
+- $\alpha_{diazo}$ is the chlorophyll-adjusted slope of the photosynthesis-irradience curve of diazotrophs (`alphabio_tri * trichlc`, [(W m<sup>-2</sup>)<sup>-1</sup>]) <br>
+- $PAR$ is the downwelling photosynthetically available radiation (`radbio`, [W m<sup>-2</sup>]) <br>
+
+---
+
+### 13. Tracer tendencies.
 
 **Nitrate** (`p_no3(i,j,k,tau)`, $NO_3$, [mol N kg<sup>-1</sup>])
 
@@ -1210,7 +1272,7 @@ $$
 \begin{align}
 \dfrac{\Delta NO_3}{\Delta t} =& \quad \bigg(\Gamma_{det}^{\rightarrow C} + \gamma_{zoo}^{\rightarrow C} \\
                                & \quad + \gamma_{phy}^{\rightarrow C} + X_{zoo}^{\leftarrow C} \\
-                               & \quad - \mu_{phy}^{\leftarrow C} \bigg) \cdot \dfrac{16}{122}
+                               & \quad - \mu_{phy}^{\leftarrow C} \bigg) \cdot \dfrac{16}{122} + \mu_{diazo}^{\rightarrow NO_{3}}
 \end{align}
 $$
 
@@ -1337,13 +1399,13 @@ $$
 ---
 
 
-### 13. Check for conservation of mass.
+### 14. Check for conservation of mass.
 
-When checks for the conservation of mass is enabled (`do_check_n_conserve = .true.` or `do_check_c_conserve = .true.`), the model will calculate the budget of nitrogen or carbon both before and after the ecosystem equations have completed. This checks that the ecosystem equations detailed above have indeed conserved the mass of both nitrogen and carbon within the ocean. In WOMBATlite, both $NO_3$ and $DIC$ should be perfectly conserved during ecosystem cycling.
+When checks for the conservation of mass is enabled (`do_check_n_conserve = .true.` or `do_check_c_conserve = .true.`), the model will calculate the budget of nitrogen or carbon both before and after the ecosystem equations have completed. This checks that the ecosystem equations detailed above have indeed conserved the mass of both nitrogen and carbon within the ocean. In WOMBATlite, both $NO_3$ and $DIC$ should be perfectly conserved during ecosystem cycling. However, the exception to this is for nitrogen, where if either of `do_nitrogen_fixation = .true.` or `do_benthic_denitrification = .true.` then the model does not and should not be expected to conserve nitrogen.
 
 ---
 
-### 14. Additional operations on tracers.
+### 15. Additional operations on tracers.
 
 **First**, dissolved iron concentrations are set to equal 1 nM everywhere where the depth of the water column is less than 200 metres deep. WOMBAT-lite is not considered to be a model of the coastal ocean, but rather a model of the global pelagic ocean. Given that coastal waters are not limited in dissolved iron due to substantial interactions with sediments and exchange with the land, we universally set the dissolved iron concentration in these waters to 1 nM.
 
@@ -1352,7 +1414,7 @@ When checks for the conservation of mass is enabled (`do_check_n_conserve = .tru
 ---
 
 
-### 15. Sinking rate of particulates.
+### 16. Sinking rate of particulates.
 
 WOMBAT-lite functions with a spatially variable sinking rate of both organic and inorganic (i.e., $CaCO_3$) particulate matter. The variable sinking rates of detritus and $CaCO_3$ are computed within the `generic_WOMBATlite_update_from_source` subroutine. Values are positive downward. Once computed, these 3D arrays are transfered to pointer arrays (`p_wdet(i,j,k)` and `p_wcaco3(i,j,k)`) that interface with a tridiagonal solver within the `g_tracer_vertdiff_G` subroutine.
 
@@ -1454,33 +1516,39 @@ WOMBAT-lite sinks organic detrital iron at the same rate as organic detrital car
 ---
 
 
-### 16. Sedimentary processes.
+### 17. Sedimentary processes.
 
 WOMBAT-lite tracks the accumulation of organic detrital carbon (`p_det_sediment(i,j)`, $B_{det,sed}^{C}$, [mol m<sup>-2</sup>]), organic detrital iron (`p_detfe_sediment(i,j)`, $B_{det,sed}^{Fe}$, [mol m<sup>-2</sup>]) and $CaCO_3$ (`p_caco3_sediment(i,j)`, $B_{CaCO_3,sed}^{C}$, [mol m<sup>-2</sup>]) within sedimentary pools. The organic pools contribute to bottom fluxes of dissolved inorganic carbon (DIC), nitrate ($NO_3$), dissolved iron (dFe), oxygen ($O_2$) and alkalinity (Alk). Remineralisation of organic carbon ($\gamma_{det,sed}^{C}$) produces DIC and $NO_3$, but removes $O_2$ and Alk. Ratios of nitrogen to carbon and oxygen to carbon are static at 16:122 and -172:122. Remineralisation of organic iron produces dFe.
+
+**Organics**
 
 $$
 \begin{align}
 \gamma_{det,sed}^{C} =& \quad \gamma_{det,sed}^{0^{\circ}C} (β_{hete})^{T} B_{det,sed}^{C} \\
-\gamma_{det,sed}^{N} =& \quad \gamma_{det,sed}^{C} R^{N:C} \\
-\gamma_{det,sed}^{O_2} =& \quad \gamma_{det,sed}^{C} R^{O_2:C} \\
+\gamma_{det,sed}^{N} =& \quad \gamma_{det,sed}^{C} R^{N:C} - \gamma_{det,sed}^{denit} \\
+\gamma_{det,sed}^{O_2} =& \quad \gamma_{det,sed}^{C} R^{O_2:C} \cdot \left(1 - f_{denit} \right) \\
 \gamma_{det,sed}^{Alk} =& \quad -\gamma_{det,sed}^{N} \\
 \gamma_{det,sed}^{Fe} =& \quad \gamma_{det,sed}^{0^{\circ}C} (β_{hete})^{T} B_{det,sed}^{Fe}
 \end{align}
 $$
 
 _where_ <br>
-- $\gamma_{det,sed}^{0^{\circ}C}$ is the base linear rate of remineralisation of sedimentary organic detritus (`detlrem_sed`, [s<sup>-1</sup>])
+- $\gamma_{det,sed}^{0^{\circ}C}$ is the base linear rate of remineralisation of sedimentary organic detritus (`detlrem_sed`, [s<sup>-1</sup>]) <br>
 - $\gamma_{det,sed}^{C}$ is the remineralisation rate of organic detrital carbon in the sediment pool (`det_sed_remin(i,j)`, [mol C m<sup>-2</sup> s<sup>-1</sup>]) <br>
 - $\gamma_{det,sed}^{N}$ is the production of nitrate due to organic detrital remineralisation in the sediment pool ([mol N m<sup>-2</sup> s<sup>-1</sup>]) <br>
+- $\gamma_{det,sed}^{denit}$ is the consumption rate of NO<sub>3</sub> due to benthic denitrification (`det_sed_denit(i,j)`, [mol N m<sup>-2</sup> s<sup>-1</sup>]) <br>
 - $\gamma_{det,sed}^{O_2}$ is the consumption rate of oxygen during remineralisation of organics in the sediment pool ([mol $O_2$ m<sup>-2</sup> s<sup>-1</sup>]) <br>
 - $\gamma_{det,sed}^{Alk}$ is the production of alkalinity due to organic detrital remineralisation in the sediment pool ([mol Alk m<sup>-2</sup> s<sup>-1</sup>]) <br>
 - $\gamma_{det,sed}^{Fe}$ is the production of dissolved iron due to organic detrital remineralisation in the sediment pool ([mol Fe m<sup>-2</sup> s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature at the sediment-water interface (`sedtemp(i,j)`, [ºC]) <br>
+- $f_{denit}$ is the fraction of organic matter being remineralised by anaerobic metabolism, i.e., denitrification (`fdenit(i,j)`, [dimensionless]) <br>
 - $B_{det,sed}^{C}$ is the total concentration of organic detrital carbon biomass (`p_det_sediment(i,j,1)`, [mol C m<sup>-2</sup>]) <br>
 - $B_{det,sed}^{Fe}$ is the total concentration of organic detrital iron biomass (`p_detfe_sediment(i,j,1)`, [mol Fe m<sup>-2</sup>]) <br>
 - $R^{N:C}$ is the static ratio of nitrogen to carbon in organic matter and is equal to 16:122 <br>
 - $R^{O_2:C}$ is the static ratio of dissolved oxygen utilisation to carbon content in organic matter and is equal to -172:122 <br>
+
+**Dissolution of $CaCO_3$**
 
 Alk and DIC are in turn affected by dissolution of the sedimenary $CaCO_3$ pool, which is considered as entirely calcite. Sedimentary dissolution is controlled by bottom water temperature and an estimate of the pore-water calcite saturation state ($\Omega_{cal}^{sed}$):
 
@@ -1495,6 +1563,30 @@ _where_ <br>
 - $\Omega_{cal,+sed}$ is the maximum possible saturation state within sediment pore water (`omegamax_sed`, [dimensionless]) <br>
 
 The $\Omega_{cal,sed}$ is calculated using the [`mocsy`](https://github.com/ACCESS-NRI/mocsy) package for solving carbonate chemistry of seawater ([Orr & Epitalon, 2015](https://doi.org/10.5194/gmd-8-485-2015)). These routines require Alk and DIC as inputs, along with nutrient concentrations and temperature and salinity of bottom waters. For DIC, we chose to sum the water column concentration of DIC and the organic carbon content of the sediment to approximate the interstitial (i.e., porewater) DIC concentration. We assume that the organic carbon content of the sediment (`p_det_sediment` [mol m<sup>-2</sup>]) is relevant over one meter, and therefore can be automatically converted to [mol m<sup>-3</sup>]. With this assumption these arrays can be added together and approximates the reducing conditions of organic-rich sediments, which have lower $\Omega_{cal,sed}$. This ensures a greater rate of $CaCO_3$ dissolution within the sediment as organic matter accumulates.
+
+**Benthic denitrification**
+
+We also consider the consumption of NO<sub>3</sub> via benthic denitrification. When `do_benthic_denitrification = .true.`, a portion of the particulate organic matter within the sediments that remineralised is performed anaerobically (i.e., using NO<sub>3</sub> as the electron acceptor). Unlike this process in the water column, which is performed by bacterial metabolism, we estimate this process using an empirical parameterization from [Bohlen et al. (2012)](https://doi.org/10.1029/2011GB004198):
+
+$$
+\begin{align}
+\gamma_{det,sed}^{denit} =& \quad \gamma_{det,sed}^{C} \min\left(0.9 \dfrac{94}{122}, \left(0.083 + 0.21 \cdot 0.98^{O_2 - NO_3} \right) \right)
+\end{align}
+$$
+
+_where_ <br>
+- $0.9$ is a hard upper limit stating that 90% of organic matter hydrolysation can potentially be performed anaerobically via denitrification <br>
+- $\dfrac{94}{122}$ is the stoichiometry of nitrate demand per mol of organic carbon hydrolysed ([Paulmier et al., 2009](https://doi.org/10.5194/bg-6-923-2009)) <br>
+- O<sub>2</sub> is the bottom water concentration of dissolved oxygen (mmol m<sup>-3</sup>) <br>
+- NO<sub>3</sub> is the bottom water concentration of nitrate (mmol m<sup>-3</sup>) <br>
+
+and where the fraction of organic matter that is remineralised via denitrification is equal to:
+
+$$
+\begin{align}
+f_{denit} =& \quad \gamma_{det,sed}^{denit} \dfrac{122/94}{\gamma_{det,sed}^{C}}
+\end{align}
+$$
 
 Overall bottom fluxes of tracers are:
 

--- a/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
+++ b/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
@@ -49,9 +49,9 @@ The following are logical statements within the `input.nml` namelist file that c
 | `do_caco3_dynamics`            | Production and dissolution of CaCO3 depends on carbon system state              | .true.           |
 | `do_colloidal_shunt`           | Fraction of dissolved iron is colloids that coagulate onto sinking material     | .true.           |
 | `do_two_ligands`               | Complex soluble iron using two ligands (weak + strong) rather than one          | .false.          |
-| `do_burial`                    | Permanently bury a fraction of sinking detrital material into the sediments     | .true.           |
-| `do_nitrogen_fixation`         | Allow implicit nitrogen fixing popoulation to add NO<sub>3</sub> to ocean       | .true.           |
-| `do_benthic_denitrification`   | Allow implicit benthic bacterial population to remove NO<sub>3</sub> from ocean | .true.           |
+| `do_burial`                    | Permanently bury a fraction of sinking detrital material into the sediments     | .false.          |
+| `do_nitrogen_fixation`         | Allow implicit nitrogen fixing popoulation to add NO<sub>3</sub> to ocean       | .false.          |
+| `do_benthic_denitrification`   | Allow implicit benthic bacterial population to remove NO<sub>3</sub> from ocean | .false.          |
 | `do_tracer_dicp`               | Carry preformed dissolved inorganic carbon (dicp) as a tracer                   | .false.          |
 | `do_tracer_dicr`               | Carry remineralised dissolved inorganic carbon (dicr) as a tracer               | .false.          |
 | `do_check_n_conserve`          | Checks that the ecosystem calculations are conserving the mass of nitrogen      | .false.          |
@@ -134,7 +134,7 @@ The following are all **3D** diagnostic output variables from WOMBAT-lite.
 | `phy_dfeupt`  | Uptake of dFe by phytoplankton                                         | mol kg<sup>-1</sup> s<sup>-1</sup>               |
 | `tri_mumax`   | Maximum growth rate of trichodesmium                                   | s<sup>-1</sup>                                   |
 | `tri_lpar`    | Limitation of trichodesmium by light                                   | dimensionless                                    |
-| `tri_lfer`    | Limitation of trichodesmkum by iron                                    | dimensionless                                    |
+| `tri_lfer`    | Limitation of trichodesmium by iron                                    | dimensionless                                    |
 | `nitrfix`     | Implicit nitrogen fixation rate (NO<sub>3</sub> production)            | mol N kg<sup>-1</sup> s<sup>-1</sup>             |
 | `feIII`       | Free iron (Fe<sup>3+</sup>)                                            | mol kg<sup>-1</sup>                              |
 | `ligK`        | Ligand stability constant                                              | L mol<sup>-1</sup>                               |
@@ -228,7 +228,7 @@ The model carries tracers in [mol kg<sup>-1</sup>]. That is, moles of solute/tra
 | `phybiot`          | Phytoplankton biomass threshold [mmolC/m³]                                  | 0.6                |
 | `alphabio_tri`     | Trichodesmium initial slope of P–I curve [(W/m²)⁻¹ (mg/mg)⁻¹]               | 1.8                |
 | `trikf`            | Trichodesmium half saturation constant for iron uptake [µmolFe/m³]          | 0.125              |
-| `trichlc`          | Trichodesmium chlorophyll to carbon ratio [mol C (mol C)<sup>-1</sup>]      | 0.01               |
+| `trichlc`          | Trichodesmium chlorophyll to carbon ratio [mol Chl (mol C)<sup>-1</sup>]    | 0.01               |
 | `trin2c`           | Trichodesmium nitrogen to carbon ratio [molN (mol C)<sup>-1</sup>]          | 50/300             |
 | `zooCingest`       | Zooplankton ingestion efficiency of carbon [molC/molC]                      | 0.8                |
 | `zooCassim`        | Zooplankton assimilation efficiency of carbon [molC/molC]                   | 0.3                |

--- a/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
+++ b/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
@@ -905,11 +905,11 @@ _where_ <br>
 - $B_{zoo}^{C}$ is the concentration of zooplankton carbon biomass (`zoo_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 
-**Remineralisation** of detritus is only affected by a quadratic, density-dependent loss term,
+**Remineralisation** of detritus is affected by a quadratic, density-dependent loss term:
 
 $$
 \begin{align}
-\Gamma_{det}^{\rightarrow C} =& \quad \Gamma_{det}^{0^{\circ}C} \left(β_{hete}\right)^{T} \left(B_{det}^{C}\right)^{2}
+\Gamma_{det}^{\rightarrow C} =& \quad \Gamma_{det}^{0^{\circ}C} \left(β_{hete}\right)^{T} L_{det}^{O_2} \left(B_{det}^{C}\right)^{2}
 \end{align}
 $$
 
@@ -918,9 +918,18 @@ _where_ <br>
 - $\Gamma_{det}^{0^{\circ}C}$ is the quadratic (density-dependent) loss rate of particulate organic detritus at 0ºC (`detlrem`, [(mmol C m<sup>-3</sup>)<sup>-1</sup> s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature (`Temp(i,j,k)`, [ºC]) <br>
+- $L_{det}^{O_2}$ is a limiter of remineralisation in low oxygen conditions (`o2lim`, [dimensionless]) <br>
 - $B_{det}^{C}$ is the concentration of particulate organic detritus (`det_mmolm3`, [mmol C m<sup>-3</sup>]) <br>
 
 since hydrolyzation of organic detritus is performed by an heterotrophic bacterial population that is not explicitly resolved in the model and their acitivity is density-dependent.
+
+Note that we also apply an oxygen limitation to detrital remineralisation at low oxygen concentrations (`o2lim`, $L_{det}^{O_2}$, [dimensionless]) based on the observed slow-down of detrital attenuation in low oxygen zones ([Engel et al., 2017](https://doi.org/10.5194/bg-14-1825-2017); [Cram et al., 2022)](https://doi.org/10.1029/2021GB007080):
+
+$$
+\begin{align}
+L_{det}^{O_2} =& \quad \left(1 - e^{\left(-O_2 \right)}\right)
+\end{align}
+$$
 
 ---
 
@@ -939,11 +948,11 @@ _where_ <br>
 - $\mu_{zoo}^{max}$ is the maximum rate of zooplankton grazing at 0ºC (`zoogmax`, [s<sup>-1</sup>]) <br>
 - $β_{hete}$ is the base temperature-sensitivity coefficient for heterotrophy (`bbioh`, [dimenionless]) <br>
 - $T$ is the in situ temperature (`Temp(i,j,k)`, [ºC]) <br>
-- $L_{zoo}^{O_2}$ is a limiter of grazing in low oxygen conditions (`zoo_o2lim`, [dimensionless]) <br>
+- $L_{zoo}^{O_2}$ is a limiter of grazing in low oxygen conditions (`o2lim`, [dimensionless]) <br>
 - $B_{prey}^{C}$ is the concentration of prey biomass (`zooprey`, [mmol C m<sup>-3</sup>]) <br>
 - $\varepsilon$ is the prey capture rate coefficient (`zooeps(i,j,k)`, [(mmol C m<sup>-3</sup>)<sup>-2</sup>]) <br>
 
-We apply an oxygen limitation to grazing at low oxygen concentrations (`zoo_o2lim`, $L_{zoo}^{O_2}$, [dimensionless]) based on the review of [Medina et al. (2017)](https://doi.org/10.3389/fmars.2017.00105) who found that from 5 µM to undetectable concentrations of oxygen, protist consumption of a bacterial population decreased from 28% to 13% of the population. Although they still see some consumption at undetectable oxygen concentrations, we scale grazing down to zero at an oxygen concentration of zero to avoid unrealistic negative oxygen concentrationsdue to grazing at zero oxygen:
+We apply an oxygen limitation to grazing at low oxygen concentrations (`o2lim`, $L_{zoo}^{O_2}$, [dimensionless]) based on the review of [Medina et al. (2017)](https://doi.org/10.3389/fmars.2017.00105), who found that from 5 µM to undetectable concentrations of oxygen, protist consumption of a bacterial population decreased from 28% to 13% of the population. Additionally, our decision to limit zooplankton grazing in low oxygen conditions is also informed by the results of [Cavan et al. (2017)](https://doi.org/10.1038/ncomms14847).
 
 $$
 \begin{align}

--- a/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
+++ b/documentation/docs/pages/Model_description/WOMBATlite_model_description.md
@@ -49,9 +49,9 @@ The following are logical statements within the `input.nml` namelist file that c
 | `do_caco3_dynamics`            | Production and dissolution of CaCO3 depends on carbon system state              | .true.           |
 | `do_colloidal_shunt`           | Fraction of dissolved iron is colloids that coagulate onto sinking material     | .true.           |
 | `do_two_ligands`               | Complex soluble iron using two ligands (weak + strong) rather than one          | .false.          |
-| `do_burial`                    | Permanently bury a fraction of sinking detrital material into the sediments     | .false.          |
-| `do_nitrogen_fixation`         | Allow implicit nitrogen fixing popoulation to add NO<sub>3</sub> to ocean       | .false.          |
-| `do_benthic_denitrification`   | Allow implicit benthic bacterial population to remove NO<sub>3</sub> from ocean | .false.          |
+| `do_burial`                    | Permanently bury a fraction of sinking detrital material into the sediments     | .true.           |
+| `do_nitrogen_fixation`         | Allow implicit nitrogen fixing popoulation to add NO<sub>3</sub> to ocean       | .true.           |
+| `do_benthic_denitrification`   | Allow implicit benthic bacterial population to remove NO<sub>3</sub> from ocean | .true.           |
 | `do_tracer_dicp`               | Carry preformed dissolved inorganic carbon (dicp) as a tracer                   | .false.          |
 | `do_tracer_dicr`               | Carry remineralised dissolved inorganic carbon (dicr) as a tracer               | .false.          |
 | `do_check_n_conserve`          | Checks that the ecosystem calculations are conserving the mass of nitrogen      | .false.          |

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2620,7 +2620,7 @@ module generic_WOMBATlite
       fbc = wombat%bbioh ** (Temp(i,j,k))
 
       ! Variable rates of remineralisation
-      o2lim = max(0.0, min(1.0, 1.0 - exp(-o2_mmolm3/1.0)))
+      o2lim = max(0.0, min(1.0, 1.0 - exp(-o2_mmolm3)))
       wombat%reminr(i,j,k) = wombat%detlrem * fbc * o2lim
 
 

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2795,7 +2795,7 @@ module generic_WOMBATlite
 
       ! Scavenging of Fe` onto biogenic particles
       partic = (det_mmolm3*2 + caco3_mmolm3*8.3)
-      wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (1e-7 + wombat%kscav_dfe * partic)
+      wombat%fescaven(i,j,k) = wombat%feIII(i,j,k) * (1e-7/86400.0 + wombat%kscav_dfe * partic)
       wombat%fescadet(i,j,k) = wombat%fescaven(i,j,k) * det_mmolm3*2 / (partic+epsi)
 
       ! Coagulation of colloidal Fe (umol/m3) to form sinking particles (mmol/m3)

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1162,6 +1162,11 @@ module generic_WOMBATlite
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
+        'sedo2', 'Oxygen concentration in the bottom layer', 'h', '1', 's', 'mol/kg', 'f')
+    wombat%id_sedo2 = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
         'seddic', 'Dissolved inorganic carbon concentration in the bottom layer', 'h', '1', 's', 'mol/kg', 'f')
     wombat%id_seddic = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
@@ -3422,8 +3427,13 @@ module generic_WOMBATlite
 
     do j = jsc,jec; do i = isc,iec;
       fbc = wombat%bbioh ** (wombat%sedtemp(i,j))
-      wombat%det_sed_remin(i,j) = wombat%detlrem_sed * fbc * wombat%p_det_sediment(i,j,1) ! [mol/m2/s]
-      wombat%detfe_sed_remin(i,j) = wombat%detlrem_sed * fbc * wombat%p_detfe_sediment(i,j,1) ! [mol/m2/s]
+      if ((wombat%sedo2(i,j) >= 0.0) .or. (wombat%sedno3(i,j) >= 0.0)) then
+        wombat%det_sed_remin(i,j) = wombat%detlrem_sed * fbc * wombat%p_det_sediment(i,j,1) ! [mol/m2/s]
+        wombat%detfe_sed_remin(i,j) = wombat%detlrem_sed * fbc * wombat%p_detfe_sediment(i,j,1) ! [mol/m2/s]
+      else
+        wombat%det_sed_remin(i,j) = 0.0
+        wombat%detfe_sed_remin(i,j) = 0.0
+      endif
 
       !!!~~~ CaCO3 dissolution ~~~!!!
       if (do_caco3_dynamics) then

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1975,7 +1975,7 @@ module generic_WOMBATlite
     real                                    :: rdtts ! 1 / dt
     real, dimension(nbands)                 :: sw_pen
     real                                    :: swpar
-    real                                    :: g_npz, g_peffect, wzphy, wzdet, zooprey
+    real                                    :: g_zoo, g_peffect, wzphy, wzdet, zooprey
     real                                    :: zooegesphyfe, zooegesdetfe
     real                                    :: zooassiphyfe, zooassidetfe
     real                                    :: zooexcrphyfe, zooexcrdetfe
@@ -1999,8 +1999,8 @@ module generic_WOMBATlite
     real                                    :: biof, biodoc
     real                                    :: phy_Fe2C, zoo_Fe2C, det_Fe2C
     real                                    :: phy_minqfe, phy_maxqfe
-    real                                    :: zoo_slmor
-    real                                    :: hco3, ddic
+    real                                    :: zoo_slmor, zoo_o2lim
+    real                                    :: hco3, ddic, do2_sink
     real                                    :: dzt_bot, dzt_bot_os
     real, dimension(:,:,:,:), allocatable   :: n_pools, c_pools
     logical                                 :: used
@@ -2790,8 +2790,13 @@ module generic_WOMBATlite
       !  - scales towards lower values (mesozooplankton) as prey biomass increases
       g_peffect = exp(-zooprey * wombat%zooepsrat)
       wombat%zooeps(i,j,k) = wombat%zooepsmin + (wombat%zooepsmax - wombat%zooepsmin) * g_peffect
-      g_npz = wombat%zoogmax * fbc * (wombat%zooeps(i,j,k) * zooprey*zooprey) / &
-              (wombat%zoogmax * fbc + (wombat%zooeps(i,j,k) * zooprey*zooprey))
+
+      ! Oxygen limitation term reducing zooplankton grazing pressure in low-oxygen waters (following Buchanan et al., 2025; Science)
+      zoo_o2lim = max(0.0, min(1.0, 1.0 - exp(-wombat%p_o2(i,j,k,tau) / (10.0 * mmol_m3_to_mol_kg))))
+
+      ! Grazing rate [s-1]
+      zval = wombat%zooeps(i,j,k) * zooprey*zooprey
+      g_zoo = wombat%zoogmax * fbc * zoo_o2lim * zval / (wombat%zoogmax * fbc + zval)
 
       ! We follow Le Mezo & Galbraith (2021) L&O - The fecal iron pump: ...
       !  - egestion, assimilation and excretion of carbon and iron by zooplankton are calculated separately
@@ -2799,8 +2804,8 @@ module generic_WOMBATlite
       !  1. zooplankton ingest C and Fe (the rest is egested)
       !  2. zooplankton assimilate the ingested C and Fe (the rest is excreted)
       if (zooprey > 1e-10) then
-        wombat%zoograzphy(i,j,k) = g_npz * zoo_p * (wombat%zooprefphy(i,j,k) * phy_mmolm3) / zooprey ! [molC/kg/s]
-        wombat%zoograzdet(i,j,k) = g_npz * zoo_p * (wombat%zooprefdet(i,j,k) * det_mmolm3) / zooprey ! [molC/kg/s]
+        wombat%zoograzphy(i,j,k) = g_zoo * zoo_p * (wombat%zooprefphy(i,j,k) * phy_mmolm3) / zooprey ! [molC/kg/s]
+        wombat%zoograzdet(i,j,k) = g_zoo * zoo_p * (wombat%zooprefdet(i,j,k) * det_mmolm3) / zooprey ! [molC/kg/s]
       else
         wombat%zoograzphy(i,j,k) = 0.0
         wombat%zoograzdet(i,j,k) = 0.0
@@ -2977,14 +2982,13 @@ module generic_WOMBATlite
 
       ! Oxygen equation ! [molO2/kg]
       !-----------------------------------------------------------------------
-      if (wombat%p_o2(i,j,k,tau) > epsi) &
-        wombat%p_o2(i,j,k,tau) = wombat%p_o2(i,j,k,tau) - 172./122. * dtsb * ( &
-                               wombat%detremi(i,j,k) + &
-                               wombat%zoomorl(i,j,k) + &
-                               wombat%zooexcrphy(i,j,k) + &
-                               wombat%zooexcrdet(i,j,k) + &
-                               wombat%phymorl(i,j,k) - &
-                               wombat%phygrow(i,j,k) )
+      wombat%p_o2(i,j,k,tau) = wombat%p_o2(i,j,k,tau) - 172./122. * dtsb * ( &
+                             wombat%detremi(i,j,k) + &
+                             wombat%zoomorl(i,j,k) + &
+                             wombat%zooexcrphy(i,j,k) + &
+                             wombat%zooexcrdet(i,j,k) + &
+                             wombat%phymorl(i,j,k) - &
+                             wombat%phygrow(i,j,k) )
 
       ! Equation for CaCO3 ! [molCaCO3/kg]
       !-----------------------------------------------------------------------

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -83,6 +83,14 @@
 !   If true, permanently bury organics and CaCO3 in sediments
 !  </DATA>
 !
+!  <DATA NAME="do_nitrogen_fixation" TYPE="logical">
+!   If true, do nitrogen fixation.
+!  </DATA>
+!
+!  <DATA NAME="do_benthic_denitrification" TYPE="logical">
+!   If true, do benthic denitrification.
+!  </DATA>
+!
 !  <DATA NAME="do_tracer_dicp" TYPE="logical">
 !   If true, do carry preformed dissolved inorganic carbon (dicp) as a tracer
 !  </DATA>
@@ -153,13 +161,16 @@ module generic_WOMBATlite
   logical :: do_colloidal_shunt  = .true.  ! do colloidal shunt and coagulation to authigenic pools?
   logical :: do_two_ligands      = .false. ! do two ligands (one strong, one weak) for iron complexation?
   logical :: do_burial           = .false. ! permanently bury organics and CaCO3 in sediments?
+  logical :: do_nitrogen_fixation = .false. ! do nitrogen fixation?
+  logical :: do_benthic_denitrification = .false. ! do benthic denitrification?
   logical :: do_tracer_dicp      = .false.  ! enable preformed dissolved inorganic carbon tracer, dicp?
   logical :: do_tracer_dicr      = .false.  ! enable remineralised dissolved inorganic carbon tracer dicr?
   logical :: do_check_n_conserve = .false. ! check that the N fluxes balance in the ecosystem
   logical :: do_check_c_conserve = .false. ! check that the C fluxes balance in the ecosystem
 
   namelist /generic_wombatlite_nml/ co2_calc, do_caco3_dynamics, do_colloidal_shunt, &
-                                    do_two_ligands, do_burial, do_tracer_dicp, do_tracer_dicr, &
+                                    do_two_ligands, do_burial, do_nitrogen_fixation, do_benthic_denitrification, &
+                                    do_tracer_dicp, do_tracer_dicr, &
                                     do_check_n_conserve, do_check_c_conserve
 
   !=======================================================================
@@ -188,6 +199,10 @@ module generic_WOMBATlite
         phymaxqf, &
         phylmor, &
         phyqmor, &
+        alphabio_tri, &
+        trikf, &
+        trichlc, &
+        trin2c, &
         zooCingest, &
         zooCassim, &
         zooFeingest, &
@@ -275,15 +290,18 @@ module generic_WOMBATlite
         detfe_btm, &
         caco3_btm, &
         det_sed_remin, &
+        det_sed_denit, &
         detfe_sed_remin, &
         caco3_sed_remin, &
         fbury, &
+        fdenit, &
         zeuphot, &
         seddep, &
         sedmask, &
         sedtemp, &
         sedsalt, &
         sedno3, &
+        sedo2, &
         seddic, &
         sedalk, &
         sedhtotal, &
@@ -308,6 +326,10 @@ module generic_WOMBATlite
         phy_lnit, &
         phy_lfer, &
         phy_dfeupt, &
+        tri_mumax, &
+        tri_lfer, &
+        tri_lpar, &
+        nitrfix, &
         feIII, &
         felig, &
         ligK, &
@@ -447,9 +469,15 @@ module generic_WOMBATlite
         id_pchl_mu = -1, &
         id_npp3d = -1, &
         id_zsp3d = -1, &
+        id_tri_mumax = -1, &
+        id_tri_lfer = -1, &
+        id_tri_lpar = -1, &
+        id_nitrfix = -1, &
         id_det_sed_remin = -1, &
+        id_det_sed_denit = -1, &
         id_det_sed_depst = -1, &
         id_fbury = -1, &
+        id_fdenit = -1, &
         id_detfe_sed_remin = -1, &
         id_detfe_sed_depst = -1, &
         id_caco3_sed_remin = -1, &
@@ -460,6 +488,7 @@ module generic_WOMBATlite
         id_sedtemp = -1, &
         id_sedsalt = -1, &
         id_sedno3 = -1, &
+        id_sedo2 = -1, &
         id_seddic = -1, &
         id_sedalk = -1, &
         id_sedhtotal = -1, &
@@ -560,6 +589,16 @@ module generic_WOMBATlite
           'Permanently burying organics and CaCO3 in sediments'
     endif
 
+    if (do_nitrogen_fixation) then
+      write (stdoutunit,*) trim(note_header), &
+          'Doing nitrogen fixation'
+    endif
+
+    if (do_benthic_denitrification) then
+      write (stdoutunit,*) trim(note_header), &
+          'Doing benthic denitrification'
+    endif
+
     if (do_tracer_dicp) then
       write (stdoutunit,*) trim(note_header), &
           'Including preformed dissolved inorganic carbon tracer, dicp'
@@ -570,9 +609,12 @@ module generic_WOMBATlite
           'Including remineralised dissolved inorganic carbon tracer, dicr'
     endif
 
-    if (do_check_n_conserve) then
+    if (do_nitrogen_fixation .or. do_benthic_denitrification) then
       write (stdoutunit,*) trim(note_header), &
-          'Checking that the ecosystem model conserves nitrogen'
+          'Nitrogen cycle has one or more of the following: nitrogen fixation, benthic denitrification'
+      if (do_check_n_conserve) then
+        call mpp_error(FATAL, "do_check_n_conserve = .true. is going to fail because the N cycle is open")
+      endif
     endif
 
     if (do_check_c_conserve) then
@@ -780,6 +822,12 @@ module generic_WOMBATlite
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
+        'det_sed_denit', 'Rate of denitrification (NO3 consumption) in accumulated sediment', &
+        'h', '1', 's', 'molN/m^2/s', 'f')
+    wombat%id_det_sed_denit = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
         'det_sed_depst', 'Rate of deposition of detritus to sediment at base of water column', &
         'h', '1', 's', 'mol/m^2/s', 'f')
     wombat%id_det_sed_depst = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
@@ -789,6 +837,12 @@ module generic_WOMBATlite
         'fbury', 'Fraction of deposited detritus permanently buried beneath sediment', &
         'h', '1', 's', '[0-1]', 'f')
     wombat%id_fbury = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'fdenit', 'Fraction of detritus remineralised via denitrification', &
+        'h', '1', 's', '[0-1]', 'f')
+    wombat%id_fdenit = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
@@ -868,6 +922,26 @@ module generic_WOMBATlite
     vardesc_temp = vardesc( &
         'phy_dfeupt', 'Uptake of dFe by phytoplankton', 'h', 'L', 's', 'mol/kg/s', 'f')
     wombat%id_phy_dfeupt = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'tri_mumax', 'Maximum growth rate of trichodesmium', 'h', 'L', 's', '/s', 'f')
+    wombat%id_tri_mumax = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'tri_lfer', 'Limitation of trichodesmium growth by iron', 'h', 'L', 's', '[0-1]', 'f')
+    wombat%id_tri_lfer = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'tri_lpar', 'Limitation of trichodesmium growth by light', 'h', 'L', 's', '[0-1]', 'f')
+    wombat%id_tri_lpar = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
+        init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
+
+    vardesc_temp = vardesc( &
+        'nitrfix', 'Nitrogen fixation rate', 'h', 'L', 's', 'molN/kg/s', 'f')
+    wombat%id_nitrfix = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
         init_time, vardesc_temp%longname, vardesc_temp%units, missing_value=missing_value1)
 
     vardesc_temp = vardesc( &
@@ -1215,7 +1289,7 @@ module generic_WOMBATlite
     ! internally to account for the different units carried in this generic
     ! version of WOMBATlite.
 
-    ! Initial slope of P-I curve [mg C (mg Chl m-3)-1 (W m-2)-1 day-1]
+    ! Initial slope of P-I curve [mol C (mol Chl)-1 (W m-2)-1]
     !-----------------------------------------------------------------------
     ! Values of chlorophyll-specific P-I slopes in units of mg C (mg Chl)-1
     !  hour-1 (µmol photons m-2 s-1)-1] typically fall within a range of:
@@ -1225,7 +1299,7 @@ module generic_WOMBATlite
     !  0.007 - 0.087  [Fineko et al., 2002 Marine Biology; references therein]
     ! These values convert to:
     !  [0.66 - 11.39], [0.22 - 20.13], [5.20 ± 0.44], [0.77 - 9.62]
-    ! mg C (mg Chl) day-1 (W m-2)-1.
+    ! mg C (mg Chl) (W m-2)-1.
     call g_tracer_add_param('alphabio', wombat%alphabio, 3.0)
 
     ! Autotrophy maximum growth rate parameter a [1/s]
@@ -1279,6 +1353,22 @@ module generic_WOMBATlite
     ! Phytoplankton biomass threshold to scale recycling [mmolC/m3]
     !-----------------------------------------------------------------------
     call g_tracer_add_param('phybiot', wombat%phybiot, 0.6)
+
+    ! Trichodesmium initial slope of P-I curve [mol C (mol Chl)-1 (W m-2)-1]
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('alphabio_tri', wombat%alphabio_tri, 1.8)
+
+    ! Trichodesmium half saturation constant for iron uptake [µmolFe/m3]
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('trikf', wombat%trikf, 0.125)
+
+    ! Trichodesmium typical chlorophyll to carbon ratio [mol Chl (mol C)-1]
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('trichlc', wombat%trichlc, 0.01)
+
+    ! Trichodesmium typical nitrogen to carbon ratio [mol N (mol C)-1]
+    !-----------------------------------------------------------------------
+    call g_tracer_add_param('trin2c', wombat%trin2c, 50.0/300.0)
 
     ! Zooplankton ingestion efficiency of prey carbon (the rest is egested) [1]
     !-----------------------------------------------------------------------
@@ -2199,6 +2289,10 @@ module generic_WOMBATlite
     wombat%phy_lnit(:,:,:) = 0.0
     wombat%phy_lfer(:,:,:) = 0.0
     wombat%phy_dfeupt(:,:,:) = 0.0
+    wombat%tri_mumax(:,:,:) = 0.0
+    wombat%tri_lpar(:,:,:) = 0.0
+    wombat%tri_lfer(:,:,:) = 0.0
+    wombat%nitrfix(:,:,:) = 0.0
     wombat%feIII(:,:,:) = 0.0
     wombat%ligK(:,:,:) = 0.0
     wombat%felig(:,:,:) = 0.0
@@ -2239,11 +2333,13 @@ module generic_WOMBATlite
     wombat%pocdiss(:,:,:) = 0.0
     wombat%zeuphot(:,:) = 0.0
     wombat%fbury(:,:) = 0.0
+    wombat%fdenit(:,:) = 0.0
     wombat%seddep(:,:) = 0.0
     wombat%sedmask(:,:) = 0.0
     wombat%sedtemp(:,:) = 0.0
     wombat%sedsalt(:,:) = 0.0
     wombat%sedno3(:,:) = 0.0
+    wombat%sedo2(:,:) = 0.0
     wombat%seddic(:,:) = 0.0
     wombat%sedalk(:,:) = 0.0
     wombat%sedhtotal(:,:) = 0.0
@@ -2316,11 +2412,12 @@ module generic_WOMBATlite
     !    9.  Mortality and remineralisation                                 !
     !    10. Zooplankton grazing, egestion, excretion and assimilation      !
     !    11. CaCO3 calculations                                             !
-    !    12. Tracer tendencies                                              !
-    !    13. Check for conservation by ecosystem component                  !
-    !    14. Additional operations on tracers                               !
-    !    15. Sinking rate of particulates                                   !
-    !    16. Sedimentary processes                                          !
+    !    12. Implicit nitrogen fixation                                     !
+    !    13. Tracer tendencies                                              !
+    !    14. Check for conservation by ecosystem component                  !
+    !    15. Additional operations on tracers                               !
+    !    16. Sinking rate of particulates                                   !
+    !    17. Sedimentary processes                                          !
     !                                                                       !
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
@@ -2862,7 +2959,32 @@ module generic_WOMBATlite
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
-      !  [Step 12] Tracer tendencies                                          !
+      !  [Step 12] Implicit nitrogen fixation                                 !
+      !-----------------------------------------------------------------------!
+      !-----------------------------------------------------------------------!
+      !-----------------------------------------------------------------------!
+
+      if (do_nitrogen_fixation) then
+        ! Temperature dependent maximum growth rate of Trichodesmium (Jiang et al., 2018)
+        if (Temp(i,j,k)>15.8) then
+          wombat%tri_mumax(i,j,k) = max(0.0, ( ( -3.99e-4 * Temp(i,j,k)**3.0 ) + &
+                                             (  0.02685 * Temp(i,j,k)**2.0 ) + &
+                                             ( -0.555 * Temp(i,j,k) ) + 3.633 )) / 86400.0
+        endif
+        ! Nutrient and light limitation terms
+        wombat%tri_lfer(i,j,k) = max(0.0, min(1.0, fe_umolm3 / (fe_umolm3 + wombat%trikf)))
+        wombat%tri_lpar(i,j,k) = max(0.0, min(1.0, (1. - exp(-wombat%alphabio_tri * wombat%trichlc * wombat%radbio(i,j,k)))))
+        ! Nitrogen fixation rate of Trichodesmium
+        wombat%nitrfix(i,j,k) = wombat%tri_mumax(i,j,k) * (1.0 - wombat%phy_lnit(i,j,k)) &
+                                * min(wombat%tri_lfer(i,j,k), wombat%tri_lpar(i,j,k)) &
+                                * wombat%trin2c * 1e-6  ! 1e-6 scaler to account for biomass in mol/kg
+      endif
+
+
+      !-----------------------------------------------------------------------!
+      !-----------------------------------------------------------------------!
+      !-----------------------------------------------------------------------!
+      !  [Step 13] Tracer tendencies                                          !
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
@@ -2966,7 +3088,8 @@ module generic_WOMBATlite
                               wombat%zooexcrphy(i,j,k) + &
                               wombat%zooexcrdet(i,j,k) + &
                               wombat%phymorl(i,j,k) - &
-                              wombat%phygrow(i,j,k) )
+                              wombat%phygrow(i,j,k) ) &
+                              + dtsb * wombat%nitrfix(i,j,k)
 
       ! Detrital iron equation ! [molFe/kg]
       !-----------------------------------------------------------------------
@@ -3079,7 +3202,7 @@ module generic_WOMBATlite
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
-      !  [Step 13] Check for conservation of mass by ecosystem component      !
+      !  [Step 14] Check for conservation of mass by ecosystem component      !
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
       !-----------------------------------------------------------------------!
@@ -3159,7 +3282,7 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
-    !  [Step 14] Additional operations on tracers                           !
+    !  [Step 15] Additional operations on tracers                           !
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
@@ -3186,7 +3309,7 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
-    !  [Step 15] Sinking of particulates                                    !
+    !  [Step 16] Sinking of particulates                                    !
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
@@ -3226,7 +3349,7 @@ module generic_WOMBATlite
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
-    !  [Step 16] Sedimentary processes                                      !
+    !  [Step 17] Sedimentary processes                                      !
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
     !-----------------------------------------------------------------------!
@@ -3251,6 +3374,7 @@ module generic_WOMBATlite
             wombat%sedtemp(i,j) = wombat%sedtemp(i,j) + Temp(i,j,k) * dzt(i,j,k) ! [m*degC]
             wombat%sedsalt(i,j) = wombat%sedsalt(i,j) + Salt(i,j,k) * dzt(i,j,k) ! [m*psu]
             wombat%sedno3(i,j) = wombat%sedno3(i,j) + wombat%p_no3(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
+            wombat%sedo2(i,j) = wombat%sedo2(i,j) + wombat%p_o2(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
             wombat%seddic(i,j) = wombat%seddic(i,j) + wombat%p_dic(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
             wombat%sedalk(i,j) = wombat%sedalk(i,j) + wombat%p_alk(i,j,k,tau) * dzt(i,j,k) ! [m*mol/kg]
             wombat%sedhtotal(i,j) = wombat%sedhtotal(i,j) + wombat%htotal(i,j,k) * dzt(i,j,k) ! [m*mol/kg]
@@ -3261,6 +3385,7 @@ module generic_WOMBATlite
         wombat%sedtemp(i,j) = wombat%sedtemp(i,j) - Temp(i,j,k_bot) * dzt_bot_os ! [m*degC]
         wombat%sedsalt(i,j) = wombat%sedsalt(i,j) - Salt(i,j,k_bot) * dzt_bot_os ! [m*psu]
         wombat%sedno3(i,j) = wombat%sedno3(i,j) - wombat%p_no3(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
+        wombat%sedo2(i,j) = wombat%sedo2(i,j) - wombat%p_o2(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
         wombat%seddic(i,j) = wombat%seddic(i,j) - wombat%p_dic(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
         wombat%sedalk(i,j) = wombat%sedalk(i,j) - wombat%p_alk(i,j,k_bot,tau) * dzt_bot_os ! [m*mol/kg]
         wombat%sedhtotal(i,j) = wombat%sedhtotal(i,j) - wombat%htotal(i,j,k_bot) * dzt_bot_os ! [m*mol/kg]
@@ -3268,6 +3393,7 @@ module generic_WOMBATlite
         wombat%sedtemp(i,j) = wombat%sedtemp(i,j) / wombat%bottom_thickness ! [degC]
         wombat%sedsalt(i,j) = wombat%sedsalt(i,j) / wombat%bottom_thickness ! [psu]
         wombat%sedno3(i,j) = wombat%sedno3(i,j) / wombat%bottom_thickness ! [mol/kg]
+        wombat%sedo2(i,j) = wombat%sedo2(i,j) / wombat%bottom_thickness ! [mol/kg]
         wombat%seddic(i,j) = wombat%seddic(i,j) / wombat%bottom_thickness ! [mol/kg]
         wombat%sedalk(i,j) = wombat%sedalk(i,j) / wombat%bottom_thickness ! [mol/kg]
         wombat%sedhtotal(i,j) = wombat%sedhtotal(i,j) / wombat%bottom_thickness ! [mol/kg]
@@ -3307,6 +3433,8 @@ module generic_WOMBATlite
       fbc = wombat%bbioh ** (wombat%sedtemp(i,j))
       wombat%det_sed_remin(i,j) = wombat%detlrem_sed * fbc * wombat%p_det_sediment(i,j,1) ! [mol/m2/s]
       wombat%detfe_sed_remin(i,j) = wombat%detlrem_sed * fbc * wombat%p_detfe_sediment(i,j,1) ! [mol/m2/s]
+
+      !!!~~~ CaCO3 dissolution ~~~!!!
       if (do_caco3_dynamics) then
         wombat%caco3_sed_remin(i,j) = wombat%caco3lrem_sed * fbc * wombat%p_caco3_sediment(i,j,1) &
                                       * max((1.0-wombat%omegamax_sed), (1.0-wombat%sedomega_cal(i,j)))**(4.5)
@@ -3315,11 +3443,24 @@ module generic_WOMBATlite
                                       * (1.0 - 0.2081)**(4.5)
       endif
 
+      !!!~~~ Benthic denitrification ~~~!!!
+      if (do_benthic_denitrification) then
+        ! sedimentary denitrification (Bohlen et al., 2012 Global Biogeochemical Cycles)
+        !   Stoichiometry of 94 mol NO3 used per 122 mol organic carbon oxidised (Paulmier et al, 2009 BG)
+        !   Hard limit where denitrification is at maximum 90% responsible for organic matter remin
+        wombat%det_sed_denit(i,j) = wombat%det_sed_remin(i,j) * min(0.9 * 94.0/122.0, &
+                                    (0.083 + 0.21 * 0.98**((wombat%sedo2(i,j) - wombat%sedno3(i,j))/mmol_m3_to_mol_kg)))
+        wombat%fdenit(i,j) = wombat%det_sed_denit(i,j) * 122.0/94.0 / (wombat%det_sed_remin(i,j) + epsi)
+      else
+        wombat%det_sed_denit(i,j) = 0.0 ! [mol/m2/s]
+        wombat%fdenit(i,j) = 0.0
+      endif
+
       ! Remineralisation of sediments to supply nutrient fields.
       ! btf values are positive from the water column into the sediment.
-      wombat%b_no3(i,j) = -16./122. * wombat%det_sed_remin(i,j) ! [mol/m2/s]
-      wombat%b_o2(i,j) = -172./16. * wombat%b_no3(i,j) ! [mol/m2/s]
-      wombat%b_dic(i,j) = 122./16. * wombat%b_no3(i,j) - wombat%caco3_sed_remin(i,j) ! [mol/m2/s]
+      wombat%b_no3(i,j) = -16./122. * wombat%det_sed_remin(i,j) + wombat%det_sed_denit(i,j) ! [mol/m2/s]
+      wombat%b_o2(i,j) = 172./122. * wombat%det_sed_remin(i,j) * (1.0 - wombat%fdenit(i,j)) ! [mol/m2/s]
+      wombat%b_dic(i,j) = -1.0 * wombat%det_sed_remin(i,j) - wombat%caco3_sed_remin(i,j) ! [mol/m2/s]
       wombat%b_fe(i,j) = -1.0 * wombat%detfe_sed_remin(i,j) ! [mol/m2/s]
       wombat%b_alk(i,j) = -2.0 * wombat%caco3_sed_remin(i,j) - wombat%b_no3(i,j) ! [mol/m2/s]
       if (do_tracer_dicr) wombat%b_dicr(i,j) = wombat%b_dic(i,j) ! [mol/m2/s]
@@ -3435,6 +3576,22 @@ module generic_WOMBATlite
 
     if (wombat%id_phy_dfeupt > 0) &
       used = g_send_data(wombat%id_phy_dfeupt, wombat%phy_dfeupt, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_tri_mumax > 0) &
+      used = g_send_data(wombat%id_tri_mumax, wombat%tri_mumax, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_tri_lpar > 0) &
+      used = g_send_data(wombat%id_tri_lpar, wombat%tri_lpar, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_tri_lfer > 0) &
+      used = g_send_data(wombat%id_tri_lfer, wombat%tri_lfer, model_time, &
+          rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
+
+    if (wombat%id_nitrfix > 0) &
+      used = g_send_data(wombat%id_nitrfix, wombat%nitrfix, model_time, &
           rmask=grid_tmask, is_in=isc, js_in=jsc, ks_in=1, ie_in=iec, je_in=jec, ke_in=nk)
 
     if (wombat%id_feIII > 0) &
@@ -3601,6 +3758,14 @@ module generic_WOMBATlite
       used = g_send_data(wombat%id_det_sed_remin, wombat%det_sed_remin, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
+    if (wombat%id_det_sed_denit > 0) &
+      used = g_send_data(wombat%id_det_sed_denit, wombat%det_sed_denit, model_time, &
+          rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+    if (wombat%id_fdenit > 0) &
+      used = g_send_data(wombat%id_fdenit, wombat%fdenit, model_time, &
+          rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
     if (wombat%id_detfe_sed_remin > 0) &
       used = g_send_data(wombat%id_detfe_sed_remin, wombat%detfe_sed_remin, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -3631,6 +3796,10 @@ module generic_WOMBATlite
 
     if (wombat%id_sedno3 > 0) &
       used = g_send_data(wombat%id_sedno3, wombat%sedno3, model_time, &
+          rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+    if (wombat%id_sedo2 > 0) &
+      used = g_send_data(wombat%id_sedo2, wombat%sedo2, model_time, &
           rmask=grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
     if (wombat%id_seddic > 0) &
@@ -3940,6 +4109,10 @@ module generic_WOMBATlite
     allocate(wombat%phy_lnit(isd:ied, jsd:jed, 1:nk)); wombat%phy_lnit(:,:,:)=0.0
     allocate(wombat%phy_lfer(isd:ied, jsd:jed, 1:nk)); wombat%phy_lfer(:,:,:)=0.0
     allocate(wombat%phy_dfeupt(isd:ied, jsd:jed, 1:nk)); wombat%phy_dfeupt(:,:,:)=0.0
+    allocate(wombat%tri_mumax(isd:ied, jsd:jed, 1:nk)); wombat%tri_mumax(:,:,:)=0.0
+    allocate(wombat%tri_lpar(isd:ied, jsd:jed, 1:nk)); wombat%tri_lpar(:,:,:)=0.0
+    allocate(wombat%tri_lfer(isd:ied, jsd:jed, 1:nk)); wombat%tri_lfer(:,:,:)=0.0
+    allocate(wombat%nitrfix(isd:ied, jsd:jed, 1:nk)); wombat%nitrfix(:,:,:)=0.0
     allocate(wombat%feIII(isd:ied, jsd:jed, 1:nk)); wombat%feIII(:,:,:)=0.0
     allocate(wombat%felig(isd:ied, jsd:jed, 1:nk)); wombat%felig(:,:,:)=0.0
     allocate(wombat%ligK(isd:ied, jsd:jed, 1:nk)); wombat%ligK(:,:,:)=0.0
@@ -3979,8 +4152,10 @@ module generic_WOMBATlite
     allocate(wombat%aradiss(isd:ied, jsd:jed, 1:nk)); wombat%aradiss(:,:,:)=0.0
     allocate(wombat%pocdiss(isd:ied, jsd:jed, 1:nk)); wombat%pocdiss(:,:,:)=0.0
     allocate(wombat%det_sed_remin(isd:ied, jsd:jed)); wombat%det_sed_remin(:,:)=0.0
+    allocate(wombat%det_sed_denit(isd:ied, jsd:jed)); wombat%det_sed_denit(:,:)=0.0
     allocate(wombat%det_btm(isd:ied, jsd:jed)); wombat%det_btm(:,:)=0.0
     allocate(wombat%fbury(isd:ied, jsd:jed)); wombat%fbury(:,:)=0.0
+    allocate(wombat%fdenit(isd:ied, jsd:jed)); wombat%fdenit(:,:)=0.0
     allocate(wombat%detfe_sed_remin(isd:ied, jsd:jed)); wombat%detfe_sed_remin(:,:)=0.0
     allocate(wombat%detfe_btm(isd:ied, jsd:jed)); wombat%detfe_btm(:,:)=0.0
     allocate(wombat%caco3_sed_remin(isd:ied, jsd:jed)); wombat%caco3_sed_remin(:,:)=0.0
@@ -3994,6 +4169,7 @@ module generic_WOMBATlite
     allocate(wombat%sedtemp(isd:ied, jsd:jed)); wombat%sedtemp(:,:)=0.0
     allocate(wombat%sedsalt(isd:ied, jsd:jed)); wombat%sedsalt(:,:)=0.0
     allocate(wombat%sedno3(isd:ied, jsd:jed)); wombat%sedno3(:,:)=0.0
+    allocate(wombat%sedo2(isd:ied, jsd:jed)); wombat%sedo2(:,:)=0.0
     allocate(wombat%seddic(isd:ied, jsd:jed)); wombat%seddic(:,:)=0.0
     allocate(wombat%sedalk(isd:ied, jsd:jed)); wombat%sedalk(:,:)=0.0
     allocate(wombat%sedhtotal(isd:ied, jsd:jed)); wombat%sedhtotal(:,:)=0.0
@@ -4056,6 +4232,10 @@ module generic_WOMBATlite
         wombat%phy_lnit, &
         wombat%phy_lfer, &
         wombat%phy_dfeupt, &
+        wombat%tri_mumax, &
+        wombat%tri_lpar, &
+        wombat%tri_lfer, &
+        wombat%nitrfix, &
         wombat%feIII, &
         wombat%felig, &
         wombat%ligK, &
@@ -4092,8 +4272,10 @@ module generic_WOMBATlite
         wombat%aradiss, &
         wombat%pocdiss, &
         wombat%det_sed_remin, &
+        wombat%det_sed_denit, &
         wombat%det_btm, &
         wombat%fbury, &
+        wombat%fdenit, &
         wombat%detfe_sed_remin, &
         wombat%detfe_btm, &
         wombat%caco3_sed_remin, &
@@ -4108,6 +4290,7 @@ module generic_WOMBATlite
         wombat%sedtemp, &
         wombat%sedsalt, &
         wombat%sedno3, &
+        wombat%sedo2, &
         wombat%seddic, &
         wombat%sedalk, &
         wombat%sedhtotal, &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -309,9 +309,6 @@ module generic_WOMBATlite
         sedomega_cal
 
     real, dimension(:,:,:), allocatable :: &
-        f_dic, &
-        f_no3, &
-        f_alk, &
         radbio, &
         radmid, &
         radmld, &
@@ -2222,12 +2219,9 @@ module generic_WOMBATlite
     ! and pco2surf, so it makes sense to set these values here rather than
     ! recalculating them in set_boundary_values.
 
-    call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=tau, &
-        positive=.true.)
-    call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=tau, &
-        positive=.true.)
-    call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=tau, &
-        positive=.true.)
+    call g_tracer_get_pointer(tracer_list, 'dic', 'field', wombat%p_dic) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'no3', 'field', wombat%p_no3) ! [mol/kg]
+    call g_tracer_get_pointer(tracer_list, 'alk', 'field', wombat%p_alk) ! [mol/kg]
 
     do k = 1,nk !{
      do j = jsc,jec; do i = isc,iec
@@ -2238,10 +2232,10 @@ module generic_WOMBATlite
      if (k==1) then !{
        call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
            Temp(:,:,k), Salt(:,:,k), &
-           wombat%f_dic(:,:,k), &
-           max(wombat%f_no3(:,:,k) / 16., 1e-9), &
+           max(0.0, wombat%p_dic(:,:,k,tau)), &
+           max(1e-9, wombat%p_no3(:,:,k,tau) / 16.), &
            wombat%sio2(:,:), &
-           wombat%f_alk(:,:,k), &
+           max(0.0, wombat%p_alk(:,:,k,tau)), &
            wombat%htotallo(:,:), wombat%htotalhi(:,:), &
            wombat%htotal(:,:,k), &
            co2_calc=trim(co2_calc), &
@@ -2258,10 +2252,10 @@ module generic_WOMBATlite
 
        call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,k), &
            Temp(:,:,k), Salt(:,:,k), &
-           wombat%f_dic(:,:,k), &
-           max(wombat%f_no3(:,:,k) / 16., 1e-9), &
+           max(0.0, wombat%p_dic(:,:,k,tau)), &
+           max(1e-9, wombat%p_no3(:,:,k,tau) / 16.), &
            wombat%sio2(:,:), &
-           wombat%f_alk(:,:,k), &
+           max(0.0, wombat%p_alk(:,:,k,tau)), &
            wombat%htotallo(:,:), wombat%htotalhi(:,:), &
            wombat%htotal(:,:,k), &
            co2_calc=trim(co2_calc), zt=wombat%zw(:,:,k), &
@@ -2374,7 +2368,6 @@ module generic_WOMBATlite
     dtsb = dt / float(ts_npzd) ! number of seconds per nested ecosystem timestep
 
     ! Get the prognostic tracer values
-    call g_tracer_get_pointer(tracer_list, 'no3', 'field', wombat%p_no3) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'phy', 'field', wombat%p_phy) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'pchl', 'field', wombat%p_pchl) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'phyfe', 'field', wombat%p_phyfe) ! [mol/kg]
@@ -2385,8 +2378,6 @@ module generic_WOMBATlite
     call g_tracer_get_pointer(tracer_list, 'o2', 'field', wombat%p_o2) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'caco3', 'field', wombat%p_caco3) ! [mol/kg]
     call g_tracer_get_pointer(tracer_list, 'fe', 'field', wombat%p_fe) ! [mol/kg]
-    call g_tracer_get_pointer(tracer_list, 'dic', 'field', wombat%p_dic) ! [mol/kg]
-    call g_tracer_get_pointer(tracer_list, 'alk', 'field', wombat%p_alk) ! [mol/kg]
     if (do_tracer_dicr) call g_tracer_get_pointer(tracer_list, 'dicr', 'field', wombat%p_dicr) ! [mol/kg]
 
     !-----------------------------------------------------------------------!
@@ -3903,12 +3894,9 @@ module generic_WOMBATlite
     ! Since the coupler values here are non-cumulative there is no need to zero them out anyway.
     if (wombat%init .OR. wombat%force_update_fluxes) then
       ! Get necessary fields
-      call g_tracer_get_values(tracer_list, 'dic', 'field', wombat%f_dic, isd, jsd, ntau=1, &
-          positive=.true.)
-      call g_tracer_get_values(tracer_list, 'no3', 'field', wombat%f_no3, isd, jsd, ntau=1, &
-          positive=.true.)
-      call g_tracer_get_values(tracer_list, 'alk', 'field', wombat%f_alk, isd, jsd, ntau=1, &
-          positive=.true.)
+      call g_tracer_get_pointer(tracer_list, 'dic', 'field', wombat%p_dic) ! [mol/kg]
+      call g_tracer_get_pointer(tracer_list, 'no3', 'field', wombat%p_no3) ! [mol/kg]
+      call g_tracer_get_pointer(tracer_list, 'alk', 'field', wombat%p_alk) ! [mol/kg]
 
       do j = jsc, jec; do i = isc, iec
           wombat%htotallo(i,j) = wombat%htotal_scale_lo * wombat%htotal(i,j,1)
@@ -3922,10 +3910,10 @@ module generic_WOMBATlite
 
       call FMS_ocmip2_co2calc(CO2_dope_vec, grid_tmask(:,:,1), &
           SST(:,:), SSS(:,:), &
-          wombat%f_dic(:,:,1), &
-          max(wombat%f_no3(:,:,1) / 16., 1e-9), &
+          max(0.0, wombat%p_dic(:,:,1,1)), &
+          max(1e-9, wombat%p_no3(:,:,1,1) / 16.), &
           wombat%sio2(:,:), &
-          wombat%f_alk(:,:,1), &
+          max(0.0, wombat%p_alk(:,:,1,1)), &
           wombat%htotallo(:,:), wombat%htotalhi(:,:), &
           wombat%htotal(:,:,1), &
           co2_calc=trim(co2_calc), &
@@ -4081,10 +4069,6 @@ module generic_WOMBATlite
     allocate(wombat%dic_vstf(isd:ied, jsd:jed)); wombat%dic_vstf(:,:)=0.0
     allocate(wombat%alk_vstf(isd:ied, jsd:jed)); wombat%alk_vstf(:,:)=0.0
 
-    allocate(wombat%f_dic(isd:ied, jsd:jed, 1:nk)); wombat%f_dic(:,:,:)=0.0
-    allocate(wombat%f_no3(isd:ied, jsd:jed, 1:nk)); wombat%f_no3(:,:,:)=0.0
-    allocate(wombat%f_alk(isd:ied, jsd:jed, 1:nk)); wombat%f_alk(:,:,:)=0.0
-
     allocate(wombat%b_no3(isd:ied, jsd:jed)); wombat%b_no3(:,:)=0.0
     allocate(wombat%b_o2(isd:ied, jsd:jed)); wombat%b_o2(:,:)=0.0
     allocate(wombat%b_dic(isd:ied, jsd:jed)); wombat%b_dic(:,:)=0.0
@@ -4203,11 +4187,6 @@ module generic_WOMBATlite
         wombat%no3_vstf, &
         wombat%dic_vstf, &
         wombat%alk_vstf)
-
-    deallocate( &
-        wombat%f_dic, &
-        wombat%f_no3, &
-        wombat%f_alk)
 
     deallocate( &
         wombat%b_no3, &

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2288,10 +2288,6 @@ module generic_WOMBATlite
     wombat%phy_lnit(:,:,:) = 0.0
     wombat%phy_lfer(:,:,:) = 0.0
     wombat%phy_dfeupt(:,:,:) = 0.0
-    wombat%tri_mumax(:,:,:) = 0.0
-    wombat%tri_lpar(:,:,:) = 0.0
-    wombat%tri_lfer(:,:,:) = 0.0
-    wombat%nitrfix(:,:,:) = 0.0
     wombat%feIII(:,:,:) = 0.0
     wombat%ligK(:,:,:) = 0.0
     wombat%felig(:,:,:) = 0.0
@@ -2344,6 +2340,12 @@ module generic_WOMBATlite
     wombat%sedhtotal(:,:) = 0.0
     wombat%sedco3(:,:) = 0.0
     wombat%sedomega_cal(:,:) = 0.0
+    if (do_nitrogen_fixation) then
+      wombat%tri_mumax(:,:,:) = 0.0
+      wombat%tri_lpar(:,:,:) = 0.0
+      wombat%tri_lfer(:,:,:) = 0.0
+      wombat%nitrfix(:,:,:) = 0.0
+    endif
 
     ! Allocate and initialise some multi-dimensional variables
     allocate(wsink(nk)); wsink(:)=0.0
@@ -3084,8 +3086,9 @@ module generic_WOMBATlite
                               wombat%zooexcrphy(i,j,k) + &
                               wombat%zooexcrdet(i,j,k) + &
                               wombat%phymorl(i,j,k) - &
-                              wombat%phygrow(i,j,k) ) &
-                              + dtsb * wombat%nitrfix(i,j,k)
+                              wombat%phygrow(i,j,k) )
+      if (do_nitrogen_fixation) &
+        wombat%p_no3(i,j,k,tau) = wombat%p_no3(i,j,k,tau) + dtsb * wombat%nitrfix(i,j,k)
 
       ! Detrital iron equation ! [molFe/kg]
       !-----------------------------------------------------------------------

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -2073,7 +2073,7 @@ module generic_WOMBATlite
     real                                    :: zooexcrphyfe, zooexcrdetfe
     real                                    :: phy_p, phyfe_p, pchl_p, zoo_p, det_p
     real                                    :: phy_mmolm3, zoo_mmolm3, det_mmolm3, no3_mmolm3
-    real                                    :: fe_umolm3, caco3_mmolm3, phyfe_mmolm3
+    real                                    :: fe_umolm3, caco3_mmolm3, phyfe_mmolm3, o2_mmolm3
     real                                    :: fbc, zval
     real                                    :: P_expl, k_loss, k_loss_zoodiss
     real, parameter                         :: epsi = 1.0e-30
@@ -2091,7 +2091,7 @@ module generic_WOMBATlite
     real                                    :: biof, biodoc
     real                                    :: phy_Fe2C, zoo_Fe2C, det_Fe2C
     real                                    :: phy_minqfe, phy_maxqfe
-    real                                    :: zoo_slmor, zoo_o2lim
+    real                                    :: zoo_slmor, o2lim
     real                                    :: hco3, ddic, do2_sink
     real                                    :: dzt_bot, dzt_bot_os
     real, dimension(:,:,:,:), allocatable   :: n_pools, c_pools
@@ -2563,6 +2563,7 @@ module generic_WOMBATlite
       phyfe_mmolm3 = phyfe_p / mmol_m3_to_mol_kg ! [mmol/m3]
       zoo_mmolm3 = zoo_p / mmol_m3_to_mol_kg ! [mmol/m3]
       det_mmolm3 = det_p / mmol_m3_to_mol_kg ! [mmol/m3]
+      o2_mmolm3 = max(0.0, wombat%p_o2(i,j,k,tau)) / mmol_m3_to_mol_kg ! [mmol/m3]
       no3_mmolm3 = max(0.0, wombat%p_no3(i,j,k,tau)) / mmol_m3_to_mol_kg ! [mmol/m3]
       fe_umolm3 = max(0.0, wombat%p_fe(i,j,k,tau)) / umol_m3_to_mol_kg ![umol/m3]
       caco3_mmolm3 = max(0.0, wombat%p_caco3(i,j,k,tau)) / mmol_m3_to_mol_kg ![mmol/m3]
@@ -2619,7 +2620,8 @@ module generic_WOMBATlite
       fbc = wombat%bbioh ** (Temp(i,j,k))
 
       ! Variable rates of remineralisation
-      wombat%reminr(i,j,k) = wombat%detlrem * fbc
+      o2lim = max(0.0, min(1.0, 1.0 - exp(-o2_mmolm3/1.0)))
+      wombat%reminr(i,j,k) = wombat%detlrem * fbc * o2lim
 
 
       !-----------------------------------------------------------------------!
@@ -2885,11 +2887,11 @@ module generic_WOMBATlite
       wombat%zooeps(i,j,k) = wombat%zooepsmin + (wombat%zooepsmax - wombat%zooepsmin) * g_peffect
 
       ! Oxygen limitation term reducing zooplankton grazing pressure in low-oxygen waters (following Buchanan et al., 2025; Science)
-      zoo_o2lim = max(0.0, min(1.0, 1.0 - exp(-wombat%p_o2(i,j,k,tau) / (10.0 * mmol_m3_to_mol_kg))))
+      o2lim = max(0.0, min(1.0, 1.0 - exp(-o2_mmolm3/10.0)))
 
       ! Grazing rate [s-1]
       zval = wombat%zooeps(i,j,k) * zooprey*zooprey
-      g_zoo = wombat%zoogmax * fbc * zoo_o2lim * zval / (wombat%zoogmax * fbc + zval)
+      g_zoo = wombat%zoogmax * fbc * o2lim * zval / (wombat%zoogmax * fbc + zval)
 
       ! We follow Le Mezo & Galbraith (2021) L&O - The fecal iron pump: ...
       !  - egestion, assimilation and excretion of carbon and iron by zooplankton are calculated separately
@@ -3287,19 +3289,20 @@ module generic_WOMBATlite
       ! mac: bottom dFe fix to 1 nM when the water is <= 200 m deep.
       if (grid_kmt(i,j) > 0) then
         k = grid_kmt(i,j)
-        if (wombat%zw(i,j,k) <= 200) wombat%p_fe(i,j,k,tau) = umol_m3_to_mol_kg * 0.999 ! [mol/kg]
-      endif
-      do k = 1,nk
-        ! pjb: tune minimum dissolved iron concentration to detection limit...
-        !       this is essential for ensuring dFe is replenished in upper ocean and actually
-        !       looks to be the secret of PISCES ability to replicate dFe limitation in the right places
-        ! Only do this where the ocean is > 200m deep to avoid truncating negative tracer concentrations
-        ! at river mouths
-        if (wombat%zw(i,j,k) > 200) then
-          wombat%p_fe(i,j,k,tau) = max(wombat%dfefloor * umol_m3_to_mol_kg, &
-                                wombat%p_fe(i,j,k,tau)) * grid_tmask(i,j,k)
+        if (wombat%zw(i,j,k) <= 200) then
+          wombat%p_fe(i,j,k,tau) = umol_m3_to_mol_kg * 0.999 ! [mol/kg]
+        else
+          do k = 1,nk
+            ! pjb: tune minimum dissolved iron concentration to detection limit...
+            !       this is essential for ensuring dFe is replenished in upper ocean and actually
+            !       looks to be the secret of PISCES ability to replicate dFe limitation in the right places
+            ! Only do this where the ocean is > 200m deep to avoid truncating negative tracer concentrations
+            ! at river mouths
+            wombat%p_fe(i,j,k,tau) = max(wombat%dfefloor * umol_m3_to_mol_kg, &
+                                         wombat%p_fe(i,j,k,tau)) * grid_tmask(i,j,k)
+          enddo
         endif
-      enddo
+      endif
     enddo; enddo
 
 

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1533,7 +1533,7 @@ module generic_WOMBATlite
     !            and 1/1000 per day in deep ocean
     !  1e-6 ---> coagulation at roughly 0.01 per day in productive surface waters
     !            and 1/10000 per day in deep ocean
-    call g_tracer_add_param('kcoag_dfe', wombat%kcoag_dfe, 1e-6/86400.0)
+    call g_tracer_add_param('kcoag_dfe', wombat%kcoag_dfe, 1e-5/86400.0)
 
     ! Rate of aggregation of colloidal iron into authigenic Fe particles [s-1]
     !-----------------------------------------------------------------------

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -1521,7 +1521,7 @@ module generic_WOMBATlite
     ! that roughly 40,000 mmol C kg-1), this translates to scavenging rates
     ! of 0.001 to 0.02 (mmol mass particles / m3)-1 day-1.
     ! NOTE that scavenging becomes less important when colloids dominate.
-    call g_tracer_add_param('kscav_dfe', wombat%kscav_dfe, 0.01/86400)
+    call g_tracer_add_param('kscav_dfe', wombat%kscav_dfe, 0.01/86400.0)
 
     ! Coagulation of dFe onto organic particles [(mmolC/m3)-1 s-1]
     !-----------------------------------------------------------------------
@@ -1533,7 +1533,7 @@ module generic_WOMBATlite
     !            and 1/1000 per day in deep ocean
     !  1e-6 ---> coagulation at roughly 0.01 per day in productive surface waters
     !            and 1/10000 per day in deep ocean
-    call g_tracer_add_param('kcoag_dfe', wombat%kcoag_dfe, 1e-5/86400)
+    call g_tracer_add_param('kcoag_dfe', wombat%kcoag_dfe, 1e-6/86400.0)
 
     ! Rate of aggregation of colloidal iron into authigenic Fe particles [s-1]
     !-----------------------------------------------------------------------
@@ -1939,7 +1939,7 @@ module generic_WOMBATlite
     if (do_burial) then
       do i = isc, iec
         do j = jsc, jec
-          orgflux = wombat%det_btm(i,j) / dt * 86400 * 1e3 ! mmol C m-2 day-1
+          orgflux = wombat%det_btm(i,j) / dt * 86400.0 * 1e3 ! mmol C m-2 day-1
           wombat%fbury(i,j) = max(0.0, 0.013 + 0.53 * (orgflux / (7.0 + orgflux))**2.0)  ! Eq. 3 Dunne et al. 2007
         enddo
       enddo
@@ -2805,14 +2805,12 @@ module generic_WOMBATlite
       biof = max(1/3., phy_mmolm3 / (phy_mmolm3 + 0.03))
       if (wombat%zw(i,j,k)<=hblt_depth(i,j)) then
         zval = (      (12.*biof*biodoc + 9.05*det_mmolm3) &
-                + 2.49*det_mmolm3 + 127.8*biof*biodoc + 725.7*det_mmolm3 &
-                + wombat%kagg_col * wombat%fecol(i,j,k)**4 / (wombat%fecol(i,j,k)**4 + wombat%kagg_kcol**4) &
-               )*wombat%kcoag_dfe
+                + 2.49*det_mmolm3 + 127.8*biof*biodoc + 725.7*det_mmolm3 )*wombat%kcoag_dfe &
+               + wombat%kagg_col * wombat%fecol(i,j,k)**4 / (wombat%fecol(i,j,k)**4 + wombat%kagg_kcol**4)
       else
         zval = ( 0.01 * (12.*biof*biodoc + 9.05*det_mmolm3) &
-                + 2.49*det_mmolm3 + 127.8*biof*biodoc + 725.7*det_mmolm3 &
-                + wombat%kagg_col * wombat%fecol(i,j,k)**4 / (wombat%fecol(i,j,k)**4 + wombat%kagg_kcol**4) &
-               )*wombat%kcoag_dfe
+                + 2.49*det_mmolm3 + 127.8*biof*biodoc + 725.7*det_mmolm3 )*wombat%kcoag_dfe &
+               + wombat%kagg_col * wombat%fecol(i,j,k)**4 / (wombat%fecol(i,j,k)**4 + wombat%kagg_kcol**4)
       endif
       wombat%fecoag2det(i,j,k) = wombat%fecol(i,j,k) * zval
 

--- a/generic_tracers/generic_WOMBATlite.F90
+++ b/generic_tracers/generic_WOMBATlite.F90
@@ -157,16 +157,16 @@ module generic_WOMBATlite
   ! Namelist Options
   !=======================================================================
   character(len=10) :: co2_calc  = 'mocsy' ! other option is 'ocmip2'
-  logical :: do_caco3_dynamics   = .true.  ! do dynamic CaCO3 precipitation, dissolution and ballasting?
-  logical :: do_colloidal_shunt  = .true.  ! do colloidal shunt and coagulation to authigenic pools?
-  logical :: do_two_ligands      = .false. ! do two ligands (one strong, one weak) for iron complexation?
-  logical :: do_burial           = .false. ! permanently bury organics and CaCO3 in sediments?
-  logical :: do_nitrogen_fixation = .false. ! do nitrogen fixation?
-  logical :: do_benthic_denitrification = .false. ! do benthic denitrification?
-  logical :: do_tracer_dicp      = .false.  ! enable preformed dissolved inorganic carbon tracer, dicp?
-  logical :: do_tracer_dicr      = .false.  ! enable remineralised dissolved inorganic carbon tracer dicr?
-  logical :: do_check_n_conserve = .false. ! check that the N fluxes balance in the ecosystem
-  logical :: do_check_c_conserve = .false. ! check that the C fluxes balance in the ecosystem
+  logical :: do_caco3_dynamics          = .true.  ! do dynamic CaCO3 precipitation, dissolution and ballasting?
+  logical :: do_colloidal_shunt         = .true.  ! do colloidal shunt and coagulation to authigenic pools?
+  logical :: do_two_ligands             = .false. ! do two ligands (one strong, one weak) for iron complexation?
+  logical :: do_burial                  = .true.  ! permanently bury organics and CaCO3 in sediments?
+  logical :: do_nitrogen_fixation       = .true.  ! do nitrogen fixation?
+  logical :: do_benthic_denitrification = .true.  ! do benthic denitrification?
+  logical :: do_tracer_dicp             = .false. ! enable preformed dissolved inorganic carbon tracer, dicp?
+  logical :: do_tracer_dicr             = .false. ! enable remineralised dissolved inorganic carbon tracer dicr?
+  logical :: do_check_n_conserve        = .false. ! check that the N fluxes balance in the ecosystem
+  logical :: do_check_c_conserve        = .false. ! check that the C fluxes balance in the ecosystem
 
   namelist /generic_wombatlite_nml/ co2_calc, do_caco3_dynamics, do_colloidal_shunt, &
                                     do_two_ligands, do_burial, do_nitrogen_fixation, do_benthic_denitrification, &


### PR DESCRIPTION
Including updates to the WOMBATlite code to deal with or potentially fix the very negative concentrations of O2 in waters close to the sediments that developed during the ACCESS-OM2-0.1º test simulation.

These fixes include:
[] An oxygen limitation for zooplankton grazing
[] Diverting O2 demand to NO3 demand in sediment remineralisation (i.e., denitrification)
[] Potentially flooring dissolved oxygen to zero and breaking conservation
[] Slowing or stopping benthic remineralisation of detritus when O2 and NO3 are not available