### PR TITLE
Add NVHPC (nvfortran) compiler support to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,14 @@ elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
   set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g3 -O2 -xCORE-AVX2 -debug all -check none")
   set(CMAKE_Fortran_FLAGS_DEBUG "-g3 -O0 -debug all -check -check noarg_temp_created -check nopointer -warn -warn noerrors -ftrapuv")
 
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC")
+
+  # NVIDIA HPC SDK (nvfortran)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -i4 -r8 -Mcray=pointer -Mbyteswapio -Ktrap=fp -traceback")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
+  set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "-g -O2")
+  set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -g -Mbounds -Mchkptr")
+
 else()
   message(WARNING "Fortran compiler with ID ${CMAKE_Fortran_COMPILER_ID} will be used with CMake default options")
 endif()


### PR DESCRIPTION
This PR is the first step in enabling NVHPC support for gtracers. It adds the nvhpc rough equivalent compile flags for the build types being used.

This PR doesn't necessarily check whether the build actually runs correctly. Hence, the warning is left in place.
This only gets the cmake build so downstream dependencies (GPU-enabled MOM6) at least build correctly with spack.

For convenience, the descriptions from the man mages for the flags being added:

```
       -Mcray=pointer
              Force Cray Fortran (CF77) compatibility with respect to the listed options.  Possible options include:

              pointer   For purposes of optimization, assume that pointer-based variables do not overlap the storage of any other variable.

       -Mbyteswapio
              Swap bytes from big-endian to little-endian or vice versa on input/output of unformatted Fortran data. Use of this option enables reading/writing of Fortran unformatted data files compatible with those
              produced on Sun or SGI systems.

       -Ktrap=option[,option]...
              Controls the behavior of the processor when floating-point exceptions occur during program execution.  Possible options include

              fp      Trap on floating-point exceptions.

       -Mbounds -Mnobounds (default)
              Add (don't add) array bound checking.

       -Mchkptr
              Check for unintended de-referencing of NULL pointers.
```